### PR TITLE
Auto set version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+      - name: Auto set version from tag
+        # Ref: https://github.com/grst/python-ci-versioneer
+        run: |
+          # from refs/tags/1.2.3 get 1.2.3
+          VERSION=$(echo $GITHUB_REF | sed 's#.*/##')
+          echo "Setting version to $VERSION"
+          PLACEHOLDER='^version\s*=.*'
+          # ensure the placeholder is there. If grep doesn't find the placeholder
+          # it exits with exit code 1 and github actions aborts the build.
+          grep -E "$PLACEHOLDER" pyproject.toml
+          sed -i "s/$PLACEHOLDER/version = \"${VERSION}\"/g" pyproject.toml
+        shell: bash
       - name: Install wheel
         run: python3 -m pip install --upgrade build
       - name: Build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.1"
+version = "0.0.1-dev"  # replaced by CI
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]


### PR DESCRIPTION
Set a placeholder in `pyproject.toml` and update it in CI (e.g. from refs/tags/1.2.3 get 1.2.3).
Expecting release tags to be the version number without a `v` prefix (same as ops and pylibjuju).