### PR TITLE
do not overwrite topology with your own

### DIFF
--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -304,7 +304,10 @@ class Rules(ABC):
                         repl = r'job=~".+"' if self.query_type == "logql" else ""
                         rule["expr"] = self.tool.inject_label_matchers(  # type: ignore
                             expression=re.sub(r"%%juju_topology%%,?", repl, rule["expr"]),
-                            topology=self.topology.alert_expression_dict,
+                            topology={
+                                k: rule["labels"][k]
+                                for k in ("juju_model", "juju_model_uuid", "juju_application")
+                            },
                             query_type=self.query_type,
                         )
 


### PR DESCRIPTION
host labels were already preserved if present, but the expression was still being overwritten.
This PR adds the labels in the expression matching the final labels attached to the rules (i.e. your own if not present, else the host's).

Closes https://github.com/canonical/grafana-agent-operator/issues/68.