### PR TITLE
Bump Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.16"
+version = "0.0.18"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]


### PR DESCRIPTION
Bump version to 0.0.18 as it was missed in https://github.com/canonical/cos-lib/pull/37

