### PR TITLE
Add safeguard on `_PebbleLogClient` static method calls 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.18"
+version = "0.0.19"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -346,20 +346,22 @@ class ManualLogForwarder(ops.Object):
             loki_endpoints = {}
 
         for container in self._charm.unit.containers.values():
-            _PebbleLogClient.disable_inactive_endpoints(
-                container=container,
-                active_endpoints=loki_endpoints,
-                topology=self._topology,
-            )
-            _PebbleLogClient.enable_endpoints(
-                container=container, active_endpoints=loki_endpoints, topology=self._topology
-            )
+            if container.can_connect():
+                _PebbleLogClient.disable_inactive_endpoints(
+                    container=container,
+                    active_endpoints=loki_endpoints,
+                    topology=self._topology,
+                )
+                _PebbleLogClient.enable_endpoints(
+                    container=container, active_endpoints=loki_endpoints, topology=self._topology
+                )
 
     def disable_logging(self, _: Optional[ops.EventBase] = None):
         """Disable all log forwarding."""
         # This is currently necessary because, after a relation broken, the charm can still see
         # the Loki endpoints in the relation data.
         for container in self._charm.unit.containers.values():
-            _PebbleLogClient.disable_inactive_endpoints(
-                container=container, active_endpoints={}, topology=self._topology
-            )
+            if container.can_connect():
+                _PebbleLogClient.disable_inactive_endpoints(
+                    container=container, active_endpoints={}, topology=self._topology
+                )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
in `worker.py`, `_PebbleLogClient` calls static methods which do operations on the container without checking if its ready or not. In occasions, where the workload image is not cached, so juju takes time to fetch it, this will raise an exception since the container is not ready yet.

