### PR TITLE
Catch SecretNotFoundError when privkey shouldn't be here

### DIFF
--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -578,7 +578,9 @@ class Coordinator(ops.Object):
             server_cert=self.cert_handler.server_cert,
             # FIXME tls_available check is due to fetching secret from vault. We should be generating a new secret.
             # see https://github.com/canonical/cos-lib/issues/49 for full context
-            privkey_secret_id=self.cluster.grant_privkey(VAULT_SECRET_LABEL) if self.tls_available else None,
+            privkey_secret_id=(
+                self.cluster.grant_privkey(VAULT_SECRET_LABEL) if self.tls_available else None
+            ),
             tracing_receivers=(
                 self._tracing_receivers_getter() if self._tracing_receivers_getter else None
             ),


### PR DESCRIPTION
## Issue
Relating coordinator to worker without certs failed with `SecretNotFoundError`


## Solution
Catch the error and return None. 


## Context
Fixes #47 


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
