### PR TITLE
cleanup tox env

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -33,7 +33,7 @@ jobs:
           sudo snap install charmcraft --classic
           python3 -m pip install tox
       - name: Run static analysis
-        run: tox -vve static
+        run: tox -vve fetch-libs,static
   linting:
     name: Linting
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
           sudo snap install charmcraft --classic
           python3 -m pip install tox
       - name: Run linters
-        run: tox -vve lint
+        run: tox -vve fetch-libs,lint
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -69,4 +69,4 @@ jobs:
           sudo snap install charmcraft --classic
           python -m pip install tox
       - name: Run tests
-        run: tox -e unit
+        run: tox -e fetch-libs,unit

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -46,6 +46,7 @@ check_libs_installed(
     "charms.loki_k8s.v1.loki_push_api",
     "charms.tempo_k8s.v2.tracing",
     "charms.observability_libs.v0.kubernetes_compute_resources_patch",
+    "charms.tls_certificates_interface.v3.tls_certificates",
 )
 
 from charms.data_platform_libs.v0.s3 import S3Requirer

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,12 @@ passenv =
   PYTHONPATH
   HOME
   PATH
+
+
+[testenv:fetch-libs]
 allowlist_externals = charmcraft
 commands =
-    # update all charm libs
+    # fetch all charm libs required by the coordinated_workers package
     charmcraft fetch-lib charms.data_platform_libs.v0.s3
     charmcraft fetch-lib charms.grafana_k8s.v0.grafana_source
     charmcraft fetch-lib charms.grafana_k8s.v0.grafana_dashboard
@@ -31,6 +34,7 @@ commands =
     charmcraft fetch-lib charms.tempo_k8s.v2.tracing
     charmcraft fetch-lib charms.observability_libs.v0.kubernetes_compute_resources_patch
     charmcraft fetch-lib charms.tls_certificates_interface.v3.tls_certificates
+
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
@@ -48,7 +52,6 @@ deps =
     ruff
     codespell
 commands =
-    {[testenv]commands}
     codespell {[vars]all_path}
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
@@ -63,7 +66,6 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib
 commands =
-    {[testenv]commands}
     pyright {[vars]src_path}
 
 [testenv:unit]
@@ -87,7 +89,6 @@ allowlist_externals =
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib
 commands =
-    {[testenv]commands}
     python -m doctest {[vars]src_path}/cosl/mandatory_relation_pairs.py
     /usr/bin/env sh -c 'stat cos-tool-amd64 > /dev/null 2>&1 || curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64'
     coverage run \


### PR DESCRIPTION
added a tox -e fetch-libs that should be manually run when requested instead of updating all libs on each env run.
This speeds up development considerably.
CI jobs that need the libs updated to run the fetch-libs env as well.