### PR TITLE
Prevent unnecessary restarts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.30"
+version = "0.0.31"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/tests/test_coordinated_workers/test_worker.py
+++ b/tests/test_coordinated_workers/test_worker.py
@@ -450,7 +450,7 @@ def test_worker_does_not_restart(restart_mock, tmp_path):
     )
     ctx.run("update_status", State(containers=[container], relations=[relation]))
 
-    assert restart_mock.call_count == 0
+    assert not restart_mock.called
 
 
 @patch.object(Worker, "_update_worker_config", MagicMock(return_value=False))

--- a/tests/test_coordinated_workers/test_worker.py
+++ b/tests/test_coordinated_workers/test_worker.py
@@ -9,10 +9,16 @@ import tenacity
 import yaml
 from ops import Framework
 from ops.pebble import Layer, ServiceStatus
-from scenario import Container, Context, ExecOutput, Mount, Relation, State
+from scenario import Container, Context, ExecOutput, Mount, Relation, Secret, State
 from scenario.runtime import UncaughtCharmError
 
-from cosl.coordinated_workers.worker import CONFIG_FILE, Worker
+from cosl.coordinated_workers.worker import (
+    CERT_FILE,
+    CLIENT_CA_FILE,
+    CONFIG_FILE,
+    KEY_FILE,
+    Worker,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -26,7 +32,13 @@ class MyCharm(ops.CharmBase):
 
     def __init__(self, framework: Framework):
         super().__init__(framework)
-        self.worker = Worker(self, "foo", lambda _: self.layer, {"cluster": "cluster"})
+        self.worker = Worker(
+            self,
+            "foo",
+            lambda _: self.layer,
+            {"cluster": "cluster"},
+            readiness_check_endpoint="http://localhost:3200/ready",
+        )
 
 
 def test_no_roles_error():
@@ -408,3 +420,90 @@ def test_config_preprocessor():
     # THEN the data gets preprocessed
     fs = Path(str(state_out.get_container("foo").get_filesystem(ctx)) + CONFIG_FILE)
     assert fs.read_text() == yaml.safe_dump(new_config)
+
+
+@patch.object(Worker, "_update_worker_config", MagicMock(return_value=False))
+@patch.object(Worker, "_set_pebble_layer", MagicMock(return_value=False))
+@patch.object(Worker, "restart")
+def test_worker_does_not_restart(restart_mock, tmp_path):
+
+    ctx = Context(
+        MyCharm,
+        meta={
+            "name": "foo",
+            "requires": {"cluster": {"interface": "cluster"}},
+            "containers": {"foo": {"type": "oci-image"}},
+        },
+        config={"options": {"role-all": {"type": "boolean", "default": True}}},
+    )
+    relation = Relation(
+        "cluster",
+        remote_app_data={
+            "worker_config": json.dumps("some: yaml"),
+        },
+    )
+    # WHEN the charm receives any event and there are no changes to the config or the layer,
+    #  but some of the services are down
+    container = Container(
+        "foo",
+        can_connect=True,
+    )
+    ctx.run("update_status", State(containers=[container], relations=[relation]))
+
+    assert restart_mock.call_count == 0
+
+
+@patch.object(Worker, "_update_worker_config", MagicMock(return_value=False))
+@patch.object(Worker, "_set_pebble_layer", MagicMock(return_value=False))
+@patch.object(Worker, "restart")
+def test_worker_does_not_restart_on_no_cert_changed(restart_mock, tmp_path):
+
+    ctx = Context(
+        MyCharm,
+        meta={
+            "name": "foo",
+            "requires": {"cluster": {"interface": "cluster"}},
+            "containers": {"foo": {"type": "oci-image"}},
+        },
+        config={"options": {"role-all": {"type": "boolean", "default": True}}},
+    )
+    relation = Relation(
+        "cluster",
+        remote_app_data={
+            "worker_config": json.dumps("some: yaml"),
+            "ca_cert": json.dumps("ca"),
+            "server_cert": json.dumps("cert"),
+            "privkey_secret_id": json.dumps("private_id"),
+        },
+    )
+
+    cert = tmp_path / "cert.cert"
+    key = tmp_path / "key.key"
+    client_ca = tmp_path / "client_ca.cert"
+
+    cert.write_text("cert")
+    key.write_text("private")
+    client_ca.write_text("ca")
+
+    container = Container(
+        "foo",
+        can_connect=True,
+        mounts={
+            "cert": Mount(CERT_FILE, cert),
+            "key": Mount(KEY_FILE, key),
+            "client_ca": Mount(CLIENT_CA_FILE, client_ca),
+        },
+    )
+
+    secret = Secret(
+        "secret:private_id",
+        label="private_id",
+        owner="app",
+        contents={0: {"private-key": "private"}},
+    )
+    ctx.run(
+        "update_status",
+        State(leader=True, containers=[container], relations=[relation], secrets=[secret]),
+    )
+
+    assert restart_mock.call_count == 0


### PR DESCRIPTION
## Issue
On every event, the workload container gets restarted due to `_update_tls_certificates` and `_set_pebble_layer` always returning True to restart.
- `_update_tls_certificates`
the logic almost always returns True even though the data in relation data might not be different than in the disk
- `_set_pebble_layer`
The `checks` layer is almost always different since pebble automatically adds a `threshold: 3` to the current layer and we don't add that to the new layer.

## Solution
- Add checks in `_update_tls_certificates` to compare relation data with data on disk
- Add `threshold: 3` to `_add_readiness_check`


