### PR TITLE
Add safeguard when resources patch is not ready

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.31"
+version = "0.0.32"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -663,8 +663,9 @@ class Coordinator(ops.Object):
         # There could be a race between the resource patch and pebble operations
         # i.e., charm code proceeds beyond a can_connect guard, and then lightkube patches the statefulset
         # and the workload is no longer available.
+        # `resources_patch` might be `None` when no resources requests or limits are requested by the charm.
         if self.resources_patch and not self.resources_patch.is_ready():
-            logger.debug("Resource patching is not yet ready. Skipping cluster update.")
+            logger.debug("Resource patch not ready yet. Skipping cluster update step.")
             return
 
         self.nginx.configure_pebble_layer()

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -405,12 +405,13 @@ class Worker(ops.Object):
         )
 
     def _reconcile(self):
-        """Run all unconditional logic."""
+        """Run all logic that is independent of what event we're processing."""
         # There could be a race between the resource patch and pebble operations
         # i.e., charm code proceeds beyond a can_connect guard, and then lightkube patches the statefulset
         # and the workload is no longer available
+        # `resources_patch` might be `None` when no resources requests or limits are requested by the charm.
         if self.resources_patch and not self.resources_patch.is_ready():
-            logger.debug("Resource patching is not yet ready. Skipping config update.")
+            logger.debug("Resource patch not ready yet. Skipping reconciliation step.")
             return
         self._update_cluster_relation()
         self._update_config()

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -406,6 +406,12 @@ class Worker(ops.Object):
 
     def _reconcile(self):
         """Run all unconditional logic."""
+        # There could be a race between the resource patch and pebble operations
+        # i.e., charm code proceeds beyond a can_connect guard, and then lightkube patches the statefulset
+        # and the workload is no longer available
+        if self.resources_patch and not self.resources_patch.is_ready():
+            logger.debug("Resource patching is not yet ready. Skipping config update.")
+            return
         self._update_cluster_relation()
         self._update_config()
 

--- a/tests/test_coordinated_workers/test_worker_status.py
+++ b/tests/test_coordinated_workers/test_worker_status.py
@@ -27,13 +27,14 @@ def _urlopen_patch(url: str, resp: str, tls: bool):
 
 
 @contextmanager
-def k8s_patch(status=ActiveStatus()):
+def k8s_patch(status=ActiveStatus(), is_ready=True):
     with patch("lightkube.core.client.GenericSyncClient"):
         with patch.multiple(
             "cosl.coordinated_workers.worker.KubernetesComputeResourcesPatch",
             _namespace="test-namespace",
             _patch=MagicMock(return_value=None),
             get_status=MagicMock(return_value=status),
+            is_ready=MagicMock(return_value=is_ready),
         ) as patcher:
             yield patcher
 

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
     PyYAML
     typing_extensions
     coverage[toml]
-    ops-scenario
+    ops-scenario<7.0.0
     cryptography
     jsonschema
     lightkube>=v0.15.4


### PR DESCRIPTION
## Issue
Intermittent issues in CI where the worker goes into error state during `start` hook.
There could be a race between the resource patch and pebble operations i.e., charm code proceeds beyond a can_connect guard, and then lightkube patches the statefulset and the workload is no longer available.

## Solution
Add a safeguard to not perform pebble operations if the patch is not done.
