### PR TITLE
fix: use the correct port for the nginx exporter

### DIFF
--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -535,7 +535,7 @@ class Coordinator(ops.Object):
         """The Prometheus scrape job for Nginx."""
         job: Dict[str, Any] = {
             "static_configs": [
-                {"targets": [f"{self.hostname}:{self.nginx.options['nginx_port']}"]}
+                {"targets": [f"{self.hostname}:{self.nginx.options['nginx_exporter_port']}"]}
             ]
         }
         return [job]


### PR DESCRIPTION
## Issue
Currently, the Nginx scrape job we set up in the coordinator (for self-monitoring) is using the wrong port (the Nginx one, instead of the Nginx exporter one).


## Solution
This PR fixes the scrape job to use the correct port.



## Testing Instructions
Pack an HA solutions using this change, relate to Prometheus, and verify the coordinator target is up.

