### PR TITLE
Re-raise the ChangeError to have more context in the logs

### DIFF
--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -555,6 +555,9 @@ class Worker(ops.Object):
         So letting juju retry the same hook will get us unstuck as soon as that contingency is resolved.
 
         See https://discourse.charmhub.io/t/its-probably-ok-for-a-unit-to-go-into-error-state/13022
+
+        Raises:
+            ChangeError, after continuously failing to restart the service.
         """
         if not self._container.exists(CONFIG_FILE):
             logger.error("cannot restart worker: config file doesn't exist (yet).")
@@ -581,12 +584,12 @@ class Worker(ops.Object):
                     # restart all services that our layer is responsible for
                     self._container.restart(*self._pebble_layer().services.keys())
 
-        except ops.pebble.ChangeError:
+        except ops.pebble.ChangeError as e:
             logger.error(
                 "failed to (re)start worker jobs. This usually means that an external resource (such as s3) "
                 "that the software needs to start is not available."
             )
-            raise
+            raise e
 
     def running_version(self) -> Optional[str]:
         """Get the running version from the worker process."""


### PR DESCRIPTION
## Issue
When tenacity [finally fails after 15 retries](https://github.com/canonical/loki-coordinator-k8s-operator/actions/runs/10814339248/job/30000613596?pr=9#step:7:2879), we have no context in the logs from the service.


## Solution
Re-raise the ChangeError to have [more context](https://github.com/canonical/operator/blob/d3b878e222e89f427527ef64c194129f40e1e928/ops/pebble.py#L486) in the logs.
