### PR TITLE
adjusted retry logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.33"
+version = "0.0.34"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/tests/test_coordinated_workers/conftest.py
+++ b/tests/test_coordinated_workers/conftest.py
@@ -1,8 +1,46 @@
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Generator
 from unittest.mock import patch
 
 import pytest
+import tenacity
+
+
+@pytest.fixture(autouse=True)
+def patch_all():
+    with ExitStack() as stack:
+        # so we don't have to wait for minutes:
+        stack.enter_context(
+            patch(
+                "cosl.coordinated_workers.worker.Worker.SERVICE_START_RETRY_WAIT",
+                new=tenacity.wait_none(),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "cosl.coordinated_workers.worker.Worker.SERVICE_START_RETRY_STOP",
+                new=tenacity.stop_after_delay(1),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "cosl.coordinated_workers.worker.Worker.SERVICE_STATUS_UP_RETRY_WAIT",
+                new=tenacity.wait_none(),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "cosl.coordinated_workers.worker.Worker.SERVICE_STATUS_UP_RETRY_STOP",
+                new=tenacity.stop_after_delay(1),
+            )
+        )
+
+        stack.enter_context(
+            patch("cosl.coordinated_workers.worker.Worker.running_version", new=lambda _: "42.42")
+        )
+
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
There was an issue with the implementation of the retry logic in the "wait for status up" phase of the worker restart.
to test: bump in a worker charm and deploy.

the typical restart block should look like:

![image](https://github.com/user-attachments/assets/92bc1b20-07ca-455c-adb9-78ac3e7fdb99)
