### PR TITLE
fix: use https in worker readiness when tls is enabled

### DIFF
--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -293,7 +293,9 @@ class Worker(ops.Object):
             check_url = check_endpoint(self)
             if self.is_tls_enabled:
                 # _replace is part of the public API, it's not a private method
-                check_url = urlparse(check_url)._replace(scheme="https").geturl()
+                parsed_url = urlparse(check_url)
+                if parsed_url.scheme == "http":
+                    check_url = parsed_url._replace(scheme="https").geturl()
             with urllib.request.urlopen(check_url) as response:
                 html: bytes = response.read()
 


### PR DESCRIPTION
## Issue
Currently, the readiness check fails when an HA solution is connected to TLS. This happens because the URL used for the readiness check is provided by the individual worker charm in the `readiness_check_endpoint` constructor argument.

However, the worker charm doesn't know if it's using TLS before instantiating the Worker object (because that's the object that handles TLS).

## Solution

The worker shared object must replace the scheme to use `https` when TLS is enabled, before executing the readiness check.


## Upgrade Notes

This won't break the default `http` behavior, but to make sure this is fully working for `https`, all the worker charms should probably pass `socket.getfqdn()` instead of `localhost` in the `readiness_check_endpoint`.
