### PR TITLE
fix: use https for scrape jobs when tls is available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.34"
+version = "0.0.35"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -528,7 +528,7 @@ class Coordinator(ops.Object):
                 ],
             }
             if self.tls_available:
-                job["scheme"] = "https" # pyright: ignore
+                job["scheme"] = "https"  # pyright: ignore
             scrape_jobs.append(job)
         return scrape_jobs
 
@@ -537,11 +537,7 @@ class Coordinator(ops.Object):
         """The Prometheus scrape job for Nginx."""
         job: Dict[str, Any] = {
             "static_configs": [
-                {
-                    "targets": [
-                        f"{self.hostname}:{self.nginx.options['nginx_exporter_port']}"
-                    ]
-                }
+                {"targets": [f"{self.hostname}:{self.nginx.options['nginx_exporter_port']}"]}
             ]
         }
 

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -537,7 +537,11 @@ class Coordinator(ops.Object):
         scheme = "https" if self.tls_available else "http"
         job: Dict[str, Any] = {
             "static_configs": [
-                {"targets": [f"{scheme}://{self.hostname}:{self.nginx.options['nginx_exporter_port']}"]}
+                {
+                    "targets": [
+                        f"{scheme}://{self.hostname}:{self.nginx.options['nginx_exporter_port']}"
+                    ]
+                }
             ]
         }
         return [job]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -505,12 +505,13 @@ class Coordinator(ops.Object):
         """The Prometheus scrape jobs for the workers connected to the coordinator."""
         scrape_jobs: List[Dict[str, Any]] = []
         worker_topologies = self.cluster.gather_topology()
+        scheme = "https" if self.tls_available else "http"
 
         for worker in worker_topologies:
             job = {
                 "static_configs": [
                     {
-                        "targets": [f"{worker['address']}:{self._worker_metrics_port}"],
+                        "targets": [f"{scheme}://{worker['address']}:{self._worker_metrics_port}"],
                     }
                 ],
                 # setting these as "labels" in the static config gets some of them

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -534,9 +534,10 @@ class Coordinator(ops.Object):
     @property
     def _nginx_scrape_jobs(self) -> List[Dict[str, Any]]:
         """The Prometheus scrape job for Nginx."""
+        scheme = "https" if self.tls_available else "http"
         job: Dict[str, Any] = {
             "static_configs": [
-                {"targets": [f"{self.hostname}:{self.nginx.options['nginx_exporter_port']}"]}
+                {"targets": [f"{scheme}://{self.hostname}:{self.nginx.options['nginx_exporter_port']}"]}
             ]
         }
         return [job]


### PR DESCRIPTION
## Issue
Closes #82.


## Solution
As the title specifies, we should use the appropriate URL scheme in scrape jobs, i.e., we should `https` when TLS is enabled and `http` otherwise.
