### PR TITLE
S3 tls cert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.35"
+version = "0.0.36"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 from dataclasses import dataclass
 from functools import partial
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -62,6 +63,8 @@ from charms.tempo_k8s.v2.tracing import TracingEndpointRequirer
 from lightkube.models.core_v1 import ResourceRequirements
 
 logger = logging.getLogger(__name__)
+
+S3_CA_CERT_PATH = "./s3_ca.crt"
 
 # The paths of the base rules to be rendered in CONSOLIDATED_ALERT_RULES_PATH
 NGINX_ORIGINAL_ALERT_RULES_PATH = "./src/prometheus_alert_rules/nginx"
@@ -452,6 +455,11 @@ class Coordinator(ops.Object):
         s3_config["access_key_id"] = s3_data.pop("access-key")
         s3_config["secret_access_key"] = s3_data.pop("secret-key")
         s3_config["bucket_name"] = s3_data.pop("bucket")
+        ca_chain = s3_data.get("tls-ca-chain")
+        if ca_chain:
+            # put the cacert to disk
+            Path(S3_CA_CERT_PATH).write_text(ca_chain[0])  # TODO: is any cert in the chain good?
+            s3_config["tls_ca_path"] = S3_CA_CERT_PATH
         return s3_config
 
     @property


### PR DESCRIPTION
## Issue
The s3 interface may pass us a tls certificate if the connection to the bucket is encrypted.
In my understanding we have no guarantee that that is the same cert we'd be getting by relating to the authority directly. So it may be that we need one certificate for tempo itself, and a different one for encrypting communications with s3.

## Solution
get the cert from the s3 relation and put it in the s3 configuration block as per (for example) [tempo docs](https://grafana.com/docs/tempo/latest/configuration/#storage) 


TBD:
- is this config uniform for loki and mimir?
- we get a CA chain from the s3 charm, but we need a single cert to configure the storage in the coordinator. which cert do we use?