### PR TITLE
Return sorted peers set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.35"
+version = "0.0.36"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/interface.py
+++ b/src/cosl/coordinated_workers/interface.py
@@ -337,7 +337,7 @@ class ClusterProvider(Object):
         for _, address_set in addresses_by_role.items():
             data.update(address_set)
 
-        return data
+        return sorted(data)
 
     def gather_roles(self) -> Dict[str, int]:
         """Go through the worker's app databags and sum the available application roles."""


### PR DESCRIPTION
## Issue
Unordered sets can cause unnecessary config changes on every hook and consequently cause unnecessary worker restarts.

## Solution
Sort `peers` set returned by `gather_addresses` that will be used to build `memberslist` configuration
