### PR TITLE
S3 tls cert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.35"
+version = "0.0.36"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.36"
+version = "0.0.37"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -475,7 +475,7 @@ class Coordinator(ops.Object):
             #  tls_server_name: Path to the CA certificate file.  # not a typo: it's the same
             # we send to the worker the chain itself, but the tempo config actually wants a path to a file
             # the worker will be responsible for putting it there
-            "tls_cert_path": worker.S3_TLS_CA_CHAIN_FILE if s3_data.tls_ca_chain else None,
+            "tls_ca_path": worker.S3_TLS_CA_CHAIN_FILE if s3_data.tls_ca_chain else None,
         }
 
         return s3_config

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -727,7 +727,7 @@ class Coordinator(ops.Object):
                 if self.remote_write_endpoints_getter
                 else None
             ),
-            s3_tls_ca_cert=self._s3_config,
+            s3_tls_ca_chain=self.s3_connection_info.tls_ca_chain,
         )
 
     def _render_workers_alert_rules(self):

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -93,7 +93,7 @@ class S3ConnectionInfo(pydantic.BaseModel):
     secret_key: str = pydantic.Field(alias="secret-key")
 
     region: Optional[str] = pydantic.Field(None)
-    tls_ca_chain: Optional[str] = pydantic.Field(None, alias="tls-ca-chain")
+    tls_ca_chain: Optional[List[str]] = pydantic.Field(None, alias="tls-ca-chain")
 
 
 @dataclass

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -95,6 +95,11 @@ class S3ConnectionInfo(pydantic.BaseModel):
     region: Optional[str] = pydantic.Field(None)
     tls_ca_chain: Optional[List[str]] = pydantic.Field(None, alias="tls-ca-chain")
 
+    @property
+    def ca_cert(self) -> Optional[str]:
+        """Unify the ca chain provided by the lib into a single cert."""
+        return "\n\n".join(self.tls_ca_chain) if self.tls_ca_chain else None
+
 
 @dataclass
 class ClusterRolesConfig:
@@ -727,7 +732,7 @@ class Coordinator(ops.Object):
                 if self.remote_write_endpoints_getter
                 else None
             ),
-            s3_tls_ca_chain=self.s3_connection_info.tls_ca_chain,
+            s3_tls_ca_chain=self.s3_connection_info.ca_cert,
         )
 
     def _render_workers_alert_rules(self):

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 from dataclasses import dataclass
 from functools import partial
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -62,6 +63,8 @@ from charms.tempo_k8s.v2.tracing import TracingEndpointRequirer
 from lightkube.models.core_v1 import ResourceRequirements
 
 logger = logging.getLogger(__name__)
+
+S3_CA_CERT_PATH = "./s3_ca.crt"
 
 # The paths of the base rules to be rendered in CONSOLIDATED_ALERT_RULES_PATH
 NGINX_ORIGINAL_ALERT_RULES_PATH = "./src/prometheus_alert_rules/nginx"
@@ -452,6 +455,11 @@ class Coordinator(ops.Object):
         s3_config["access_key_id"] = s3_data.pop("access-key")
         s3_config["secret_access_key"] = s3_data.pop("secret-key")
         s3_config["bucket_name"] = s3_data.pop("bucket")
+        ca_chain = s3_data.get("tls-ca-chain")
+        if ca_chain:
+            # put the cacert to disk
+            Path(S3_CA_CERT_PATH).write_text(ca_chain[0])  # TODO: is any cert in the chain good?
+            s3_config["tls_ca_path"] = S3_CA_CERT_PATH
         return s3_config
 
     @property

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -28,6 +28,7 @@ from urllib.parse import urlparse
 import ops
 import pydantic
 import yaml
+from ops import StatusBase
 
 import cosl
 from cosl.coordinated_workers import worker
@@ -452,7 +453,8 @@ class Coordinator(ops.Object):
     def s3_connection_info(self) -> S3ConnectionInfo:
         """Cast and validate the untyped s3 databag to something we can handle."""
         try:
-            return S3ConnectionInfo(**self.s3_requirer.get_s3_connection_info())
+            # we have to type-ignore here because the s3 lib's type annotation is wrong
+            return S3ConnectionInfo(**self.s3_requirer.get_s3_connection_info())  # type: ignore
         except pydantic.ValidationError:
             raise S3NotFoundError("s3 integration inactive or interface corrupt")
 
@@ -633,7 +635,7 @@ class Coordinator(ops.Object):
     # keep this event handler at the bottom
     def _on_collect_unit_status(self, e: ops.CollectStatusEvent):
         # todo add [nginx.workload] statuses
-        statuses = []
+        statuses: List[StatusBase] = []
 
         if self.resources_patch and self.resources_patch.get_status().name != "active":
             statuses.append(self.resources_patch.get_status())

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -473,13 +473,8 @@ class Coordinator(ops.Object):
             "secret_access_key": s3_data.secret_key,
             "bucket_name": s3_data.bucket,
             "insecure": not s3_data.tls_ca_chain,
-            # FIXME: s3 gives us a cert chain. tempo's s3 config takes:
-            #  tls_cert_path: Path to the client certificate file.
-            #  tls_key_path: Path to the private client key file.
-            #  tls_ca_path: Path to the CA certificate file.
-            #  tls_server_name: Path to the CA certificate file.  # not a typo: it's the same
-            # we send to the worker the chain itself, but the tempo config actually wants a path to a file
-            # the worker will be responsible for putting it there
+            # the tempo config wants a path to a file here. We pass the cert chain separately
+            # over the cluster relation; the worker will be responsible for writing the file to disk
             "tls_ca_path": worker.S3_TLS_CA_CHAIN_FILE if s3_data.tls_ca_chain else None,
         }
 
@@ -661,7 +656,6 @@ class Coordinator(ops.Object):
 
         for status in statuses:
             e.add_status(status)
-
 
     ###################
     # UTILITY METHODS #

--- a/src/cosl/coordinated_workers/interface.py
+++ b/src/cosl/coordinated_workers/interface.py
@@ -535,9 +535,9 @@ class ClusterRequirer(Object):
         if not data:
             return None
 
-        if not allow_none and (
+        if (
             not data.ca_cert or not data.server_cert or not data.privkey_secret_id
-        ):
+        ) and not allow_none:
             return None
 
         return TLSData(

--- a/src/cosl/coordinated_workers/interface.py
+++ b/src/cosl/coordinated_workers/interface.py
@@ -529,13 +529,15 @@ class ClusterRequirer(Object):
             return data.loki_endpoints or {}
         return {}
 
-    def get_tls_data(self) -> Optional[TLSData]:
+    def get_tls_data(self, allow_none: bool = False) -> Optional[TLSData]:
         """Fetch certificates and the private key secrets id for the worker config."""
         data = self._get_data_from_coordinator()
         if not data:
             return None
 
-        if not data.ca_cert or not data.server_cert or not data.privkey_secret_id:
+        if not allow_none and (
+            not data.ca_cert or not data.server_cert or not data.privkey_secret_id
+        ):
             return None
 
         return TLSData(

--- a/src/cosl/coordinated_workers/interface.py
+++ b/src/cosl/coordinated_workers/interface.py
@@ -12,7 +12,6 @@ it does not live in a charm lib as most other relation endpoint wrappers do.
 import collections
 import json
 import logging
-from collections import namedtuple
 from typing import (
     Any,
     Counter,
@@ -22,6 +21,7 @@ from typing import (
     List,
     Mapping,
     MutableMapping,
+    NamedTuple,
     Optional,
     Set,
 )
@@ -193,15 +193,13 @@ class ClusterProviderAppData(DatabagModel):
     s3_tls_ca_chain: Optional[str] = None
 
 
-TLSData = namedtuple(
-    "TLSData",
-    [
-        "ca_cert",
-        "server_cert",
-        "privkey_secret_id",
-        "s3_tls_ca_chain",
-    ],
-)
+class TLSData(NamedTuple):
+    """Section of the cluster data that concerns TLS information."""
+
+    ca_cert: Optional[str]
+    server_cert: Optional[str]
+    privkey_secret_id: Optional[str]
+    s3_tls_ca_chain: Optional[str]
 
 
 class ClusterChangedEvent(ops.EventBase):
@@ -280,7 +278,7 @@ class ClusterProvider(Object):
         worker_config: str,
         ca_cert: Optional[str] = None,
         server_cert: Optional[str] = None,
-        s3_tls_ca_cert: Optional[str] = None,
+        s3_tls_ca_chain: Optional[str] = None,
         privkey_secret_id: Optional[str] = None,
         loki_endpoints: Optional[Dict[str, str]] = None,
         tracing_receivers: Optional[Dict[str, str]] = None,
@@ -297,7 +295,7 @@ class ClusterProvider(Object):
                     privkey_secret_id=privkey_secret_id,
                     tracing_receivers=tracing_receivers,
                     remote_write_endpoints=remote_write_endpoints,
-                    s3_tls_ca_cert=s3_tls_ca_cert,
+                    s3_tls_ca_chain=s3_tls_ca_chain,
                 )
                 local_app_databag.dump(relation.data[self.model.app])
 

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -40,8 +40,10 @@ from lightkube.models.core_v1 import ResourceRequirements
 BASE_DIR = "/worker"
 CONFIG_FILE = "/etc/worker/config.yaml"
 CERT_FILE = "/etc/worker/server.cert"
+S3_TLS_CA_CHAIN_FILE = "/etc/worker/s3_ca.crt"
 KEY_FILE = "/etc/worker/private.key"
 CLIENT_CA_FILE = "/etc/worker/ca.cert"
+ROOT_CA_CERT = Path("/usr/local/share/ca-certificates/ca.crt")
 
 logger = logging.getLogger(__name__)
 
@@ -68,9 +70,6 @@ _ResourceLimitOptionsMapping = TypedDict(
     },
 )
 """Mapping of the resources limit option names that the charms use, as defined in config.yaml."""
-
-
-ROOT_CA_CERT = Path("/usr/local/share/ca-certificates/ca.crt")
 
 
 class WorkerError(Exception):
@@ -143,7 +142,7 @@ class Worker(ops.Object):
         self._name = name
         self._pebble_layer = partial(
             pebble_layer, self
-        )  #  do not call this directly. use self.pebble_layer instead
+        )  # do not call this directly. use self.pebble_layer instead
         self.topology = JujuTopology.from_charm(self._charm)
         self._container = self._charm.unit.get_container(name)
 
@@ -553,64 +552,59 @@ class Worker(ops.Object):
         if not self._container.can_connect():
             return False
 
+        any_changes = False
         if tls_data := self.cluster.get_tls_data():
-            private_key_secret = self.model.get_secret(id=tls_data["privkey_secret_id"])
+            private_key_secret = self.model.get_secret(id=tls_data.privkey_secret_id)
             private_key = private_key_secret.get_content().get("private-key")
 
-            ca_cert = tls_data["ca_cert"]
-            server_cert = tls_data["server_cert"]
-
-            # Read the current content of the files (if they exist)
-            current_server_cert = (
-                self._container.pull(CERT_FILE).read() if self._container.exists(CERT_FILE) else ""
-            )
-            current_private_key = (
-                self._container.pull(KEY_FILE).read() if self._container.exists(KEY_FILE) else ""
-            )
-            current_ca_cert = (
-                self._container.pull(CLIENT_CA_FILE).read()
-                if self._container.exists(CLIENT_CA_FILE)
-                else ""
-            )
-
-            if (
-                current_server_cert == server_cert
-                and current_private_key == private_key
-                and current_ca_cert == ca_cert
+            for new_contents, file in (
+                (tls_data.ca_cert, CLIENT_CA_FILE),
+                (tls_data.server_cert, CERT_FILE),
+                (private_key, KEY_FILE),
+                (tls_data.s3_tls_ca_chain, S3_TLS_CA_CHAIN_FILE),
             ):
-                # No update needed
-                return False
+                if self._container.exists(file):
+                    current_contents = self._container.pull(file).read()
+                    if current_contents == new_contents:
+                        continue
 
-            # Save the workload certificates
-            self._container.push(CERT_FILE, server_cert or "", make_dirs=True)
-            self._container.push(KEY_FILE, private_key or "", make_dirs=True)
-            self._container.push(CLIENT_CA_FILE, ca_cert or "", make_dirs=True)
-            self._container.push(ROOT_CA_CERT, ca_cert or "", make_dirs=True)
+                any_changes = True
+                self._container.push(file, new_contents or "", make_dirs=True)
 
             # Save the cacert in the charm container for charm traces
-            ROOT_CA_CERT.write_text(ca_cert)
-        else:
+            ROOT_CA_CERT.write_text(tls_data.ca_cert)
+            if not any_changes:
+                return False
+            logger.debug("found new tls data in cluster. synced with container fs")
 
-            if not (
-                self._container.exists(CERT_FILE)
-                or self._container.exists(KEY_FILE)
-                or self._container.exists(CLIENT_CA_FILE)
-                or self._container.exists(ROOT_CA_CERT)
+        else:
+            if not any(
+                self._container.exists(file)
+                for file in (
+                    CERT_FILE,
+                    KEY_FILE,
+                    CLIENT_CA_FILE,
+                    ROOT_CA_CERT,
+                    S3_TLS_CA_CHAIN_FILE,
+                )
             ):
                 # No update needed
                 return False
+            logger.debug("no tls data in cluster. wiping files...")
 
             self._container.remove_path(CERT_FILE, recursive=True)
             self._container.remove_path(KEY_FILE, recursive=True)
             self._container.remove_path(CLIENT_CA_FILE, recursive=True)
             self._container.remove_path(ROOT_CA_CERT, recursive=True)
+            self._container.remove_path(S3_TLS_CA_CHAIN_FILE, recursive=True)
 
             # Remove from charm container
             ROOT_CA_CERT.unlink(missing_ok=True)
 
-        # FIXME: uncomment as soon as the nginx image contains the ca-certificates package
-        self._container.exec(["update-ca-certificates", "--fresh"]).wait()
-        subprocess.run(["update-ca-certificates", "--fresh"])
+        if any_changes:
+            logger.debug("running update-ca-certificates")
+            self._container.exec(["update-ca-certificates", "--fresh"]).wait()
+            subprocess.run(["update-ca-certificates", "--fresh"])
 
         return True
 

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -584,11 +584,11 @@ class Worker(ops.Object):
             self._container.push(file, new_contents, make_dirs=True)
 
         # Save the cacert in the charm container for charm traces
+        # we do it unconditionally to avoid the extra complexity.
         if tls_data.ca_cert:
             ROOT_CA_CERT.write_text(tls_data.ca_cert)
         else:
             ROOT_CA_CERT.unlink(missing_ok=True)
-
         return any_changes
 
     def _update_tls_certificates(self) -> bool:

--- a/tests/test_coordinated_workers/test_coordinator.py
+++ b/tests/test_coordinated_workers/test_coordinator.py
@@ -173,3 +173,64 @@ def test_without_s3_integration_raises_error(
         # THEN the _s3_config method raises and S3NotFoundError
         with pytest.raises(S3NotFoundError):
             mgr.charm.coordinator._s3_config
+
+
+@pytest.mark.parametrize("region", (None, "canada"))
+@pytest.mark.parametrize("tls_ca_chain", (None, "my ca chain"))
+@pytest.mark.parametrize("bucket", ("bucky",))
+@pytest.mark.parametrize("secret_key", ("foo",))
+@pytest.mark.parametrize("access_key", ("foo",))
+@pytest.mark.parametrize(
+    "endpoint, endpoint_stripped",
+    (
+        ("example.com", "example.com"),
+        ("http://example.com", "example.com"),
+        ("https://example.com", "example.com"),
+    ),
+)
+def test_s3_integration(
+    coordinator_state: State,
+    coordinator_charm: ops.CharmBase,
+    region,
+    endpoint,
+    endpoint_stripped,
+    secret_key,
+    access_key,
+    bucket,
+    tls_ca_chain,
+):
+    # Test that a charm with a s3 integration gives the expected _s3_config
+
+    # GIVEN a coordinator charm with a s3 integration
+    ctx = Context(coordinator_charm, meta=coordinator_charm.META)
+    s3_relation = coordinator_state.get_relations("my-s3")[0]
+    relations_except_s3 = [
+        relation for relation in coordinator_state.relations if relation.endpoint != "my-s3"
+    ]
+    s3_app_data = {
+        **({"region": region} if region else {}),
+        **({"tls-ca-chain": tls_ca_chain} if tls_ca_chain else {}),
+        "endpoint": endpoint,
+        "access-key": access_key,
+        "secret-key": secret_key,
+        "bucket": bucket,
+    }
+
+    # WHEN we process any event
+    with ctx.manager(
+        "update-status",
+        state=coordinator_state.replace(
+            relations=relations_except_s3 + [s3_relation.replace(remote_app_data=s3_app_data)]
+        ),
+    ) as mgr:
+
+        # THEN the s3_connection_info method returns the expected data structure
+        coordinator: Coordinator = mgr.charm.coordinator
+        assert coordinator.s3_connection_info.region == region
+        assert coordinator.s3_connection_info.bucket == bucket
+        assert coordinator.s3_connection_info.endpoint == endpoint
+        assert coordinator.s3_connection_info.secret_key == secret_key
+        assert coordinator.s3_connection_info.access_key == access_key
+        assert coordinator.s3_connection_info.tls_ca_chain == tls_ca_chain
+        assert coordinator._s3_config["endpoint"] == endpoint_stripped
+        assert coordinator._s3_config["insecure"] is (not tls_ca_chain)

--- a/tests/test_coordinated_workers/test_coordinator.py
+++ b/tests/test_coordinated_workers/test_coordinator.py
@@ -1,3 +1,5 @@
+import json
+
 import ops
 import pytest
 from ops import Framework
@@ -176,7 +178,7 @@ def test_without_s3_integration_raises_error(
 
 
 @pytest.mark.parametrize("region", (None, "canada"))
-@pytest.mark.parametrize("tls_ca_chain", (None, "my ca chain"))
+@pytest.mark.parametrize("tls_ca_chain", (None, ["my ca chain"]))
 @pytest.mark.parametrize("bucket", ("bucky",))
 @pytest.mark.parametrize("secret_key", ("foo",))
 @pytest.mark.parametrize("access_key", ("foo",))
@@ -208,12 +210,15 @@ def test_s3_integration(
         relation for relation in coordinator_state.relations if relation.endpoint != "my-s3"
     ]
     s3_app_data = {
-        **({"region": region} if region else {}),
-        **({"tls-ca-chain": tls_ca_chain} if tls_ca_chain else {}),
-        "endpoint": endpoint,
-        "access-key": access_key,
-        "secret-key": secret_key,
-        "bucket": bucket,
+        k: json.dumps(v)
+        for k, v in {
+            **({"region": region} if region else {}),
+            **({"tls-ca-chain": tls_ca_chain} if tls_ca_chain else {}),
+            "endpoint": endpoint,
+            "access-key": access_key,
+            "secret-key": secret_key,
+            "bucket": bucket,
+        }.items()
     }
 
     # WHEN we process any event

--- a/tests/test_coordinated_workers/test_coordinator_status.py
+++ b/tests/test_coordinated_workers/test_coordinator_status.py
@@ -138,7 +138,7 @@ def test_status_check_no_s3(ctx, base_state, worker, caplog):
     state_out = ctx.run("config_changed", state)
 
     # THEN the charm sets blocked
-    assert state_out.unit_status == BlockedStatus("[consistency] Missing S3 integration.")
+    assert state_out.unit_status == BlockedStatus("[s3] Missing S3 integration.")
 
 
 @patch(
@@ -188,4 +188,4 @@ def test_status_check_k8s_patch_success_after_retries(
         MagicMock(return_value=ActiveStatus("")),
     ):
         state_out = ctx.run("update_status", state_intermediate)
-    assert state_out.unit_status == ActiveStatus("[coordinator] Degraded.")
+    assert state_out.unit_status == ActiveStatus("Degraded.")

--- a/tests/test_coordinated_workers/test_worker.py
+++ b/tests/test_coordinated_workers/test_worker.py
@@ -149,7 +149,10 @@ def test_worker_restarts_if_some_service_not_up(tmp_path):
         "foo",
         can_connect=True,
         mounts={"local": Mount(CONFIG_FILE, cfg)},
-        exec_mock={("update-ca-certificates", "--fresh"): ExecOutput()},
+        exec_mock={
+            ("update-ca-certificates", "--fresh"): ExecOutput(),
+            ("/bin/foo", "-version"): ExecOutput(stdout="foo"),
+        },
         service_status={
             "foo": ServiceStatus.INACTIVE,
             "bar": ServiceStatus.ACTIVE,
@@ -215,7 +218,10 @@ def test_worker_does_not_restart_external_services(tmp_path):
     cfg.write_text("some: yaml")
     container = Container(
         "foo",
-        exec_mock={("update-ca-certificates", "--fresh"): ExecOutput()},
+        exec_mock={
+            ("update-ca-certificates", "--fresh"): ExecOutput(),
+            ("/bin/foo", "-version"): ExecOutput(stdout="foo"),
+        },
         can_connect=True,
         mounts={"local": Mount(CONFIG_FILE, cfg)},
         layers={"foo": MyCharm.layer, "bar": other_layer},


### PR DESCRIPTION
## Issue
sthe s3 interface may give to the coordinator a "tls-ca-chain" that the worker is expected to use when using the provisioned storage bucket.
At the moment we are not doing anything with it, which means Worker charms can't use storage that is behind tls

Also there is a bad assumption within the coordinator's s3 config, that the "endpoint" we receive via the s3 integration has a scheme prefix. We use that to determine whether insecure=True.
Not only insecure=False will not work given we don't give the worker a tls cert for the storage configuration, but also it turns out the s3 interface doesn't always give us a full url, but could also give us a fqdn (i.e. no scheme).

## Solution
add a field to the cluster schema
coordinator puts there the cert if present in s3 databag, worker picks it up and puts it to filesystem
coordinator uses the cert's presence to determine if `insecure=true` instead of the endpoint scheme.

## Context
too much to tell

## Testing Instructions
added some unittests
we should try to deploy tempo HA with this lib, configure s3 to use a certificate, relate and see if it works.
