### PR TITLE
Push CA cert to workload container's `ROOT_CA_CERT` path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.38"
+version = "0.0.39"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -43,7 +43,8 @@ CERT_FILE = "/etc/worker/server.cert"
 S3_TLS_CA_CHAIN_FILE = "/etc/worker/s3_ca.crt"
 KEY_FILE = "/etc/worker/private.key"
 CLIENT_CA_FILE = "/etc/worker/ca.cert"
-ROOT_CA_CERT = Path("/usr/local/share/ca-certificates/ca.crt")
+ROOT_CA_CERT = "/usr/local/share/ca-certificates/ca.crt"
+ROOT_CA_CERT_PATH = Path(ROOT_CA_CERT)
 
 logger = logging.getLogger(__name__)
 
@@ -587,9 +588,9 @@ class Worker(ops.Object):
         # Save the cacert in the charm container for charm traces
         # we do it unconditionally to avoid the extra complexity.
         if tls_data.ca_cert:
-            ROOT_CA_CERT.write_text(tls_data.ca_cert)
+            ROOT_CA_CERT_PATH.write_text(tls_data.ca_cert)
         else:
-            ROOT_CA_CERT.unlink(missing_ok=True)
+            ROOT_CA_CERT_PATH.unlink(missing_ok=True)
         return any_changes
 
     def _update_tls_certificates(self) -> bool:
@@ -740,14 +741,14 @@ class Worker(ops.Object):
                 raise RuntimeError(
                     "Cannot send traces to an https endpoint without a certificate."
                 )
-            elif not ROOT_CA_CERT.exists():
+            elif not ROOT_CA_CERT_PATH.exists():
                 # if endpoint is https and we have a tls integration BUT we don't have the
                 # server_cert on disk yet (this could race with _update_tls_certificates):
                 # put it there and proceed
-                ROOT_CA_CERT.parent.mkdir(parents=True, exist_ok=True)
-                ROOT_CA_CERT.write_text(server_ca_cert)
+                ROOT_CA_CERT_PATH.parent.mkdir(parents=True, exist_ok=True)
+                ROOT_CA_CERT_PATH.write_text(server_ca_cert)
 
-            return endpoint, str(ROOT_CA_CERT)
+            return endpoint, ROOT_CA_CERT
         else:
             return endpoint, None
 

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -562,6 +562,7 @@ class Worker(ops.Object):
             (tls_data.server_cert, CERT_FILE),
             (private_key, KEY_FILE),
             (tls_data.s3_tls_ca_chain, S3_TLS_CA_CHAIN_FILE),
+            (tls_data.ca_cert, ROOT_CA_CERT),
         ):
             if not new_contents:
                 if self._container.exists(file):

--- a/tests/test_coordinated_workers/conftest.py
+++ b/tests/test_coordinated_workers/conftest.py
@@ -39,5 +39,11 @@ def patch_all(tmp_path: Path):
         stack.enter_context(
             patch("cosl.coordinated_workers.worker.ROOT_CA_CERT", new=tmp_path / "rootcacert")
         )
+        stack.enter_context(
+            patch(
+                "cosl.coordinated_workers.worker.ROOT_CA_CERT_PATH",
+                new=Path(tmp_path / "rootcacert"),
+            )
+        )
 
         yield

--- a/tests/test_coordinated_workers/test_worker.py
+++ b/tests/test_coordinated_workers/test_worker.py
@@ -469,6 +469,7 @@ def test_worker_does_not_restart_on_no_cert_changed(restart_mock, tmp_path):
     key = tmp_path / "key.key"
     client_ca = tmp_path / "client_ca.cert"
     s3_ca_chain = tmp_path / "s3_ca_chain.cert"
+    root_ca_mocked_path = tmp_path / "rootcacert"
 
     cert.write_text("cert")
     key.write_text("private")
@@ -484,6 +485,7 @@ def test_worker_does_not_restart_on_no_cert_changed(restart_mock, tmp_path):
             "key": Mount(KEY_FILE, key),
             "client_ca": Mount(CLIENT_CA_FILE, client_ca),
             "s3_ca_chain": Mount(S3_TLS_CA_CHAIN_FILE, s3_ca_chain),
+            "root_ca": Mount(root_ca_mocked_path, client_ca),
         },
     )
 


### PR DESCRIPTION
## Issue
Tempo config expects CA cert to be in `/usr/local/share/ca-certificates/ca.crt`

## Solution
Push CA to that location
