### PR TITLE
Add LogForwarder to coordinator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.40"
+version = "0.0.41"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -40,8 +40,6 @@ from cosl.coordinated_workers.nginx import (
 )
 from cosl.helpers import check_libs_installed
 
-from lib.charms.loki_k8s.v1.loki_push_api import LogForwarder
-
 check_libs_installed(
     "charms.data_platform_libs.v0.s3",
     "charms.grafana_k8s.v0.grafana_source",
@@ -56,7 +54,7 @@ check_libs_installed(
 
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
-from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer
+from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer, LogForwarder
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     KubernetesComputeResourcesPatch,
     adjust_resource_requirements,

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -40,6 +40,8 @@ from cosl.coordinated_workers.nginx import (
 )
 from cosl.helpers import check_libs_installed
 
+from lib.charms.loki_k8s.v1.loki_push_api import LogForwarder
+
 check_libs_installed(
     "charms.data_platform_libs.v0.s3",
     "charms.grafana_k8s.v0.grafana_source",
@@ -283,6 +285,7 @@ class Coordinator(ops.Object):
         )
 
         self._logging = LokiPushApiConsumer(self._charm, relation_name=self._endpoints["logging"])
+        self._log_forwarder = LogForwarder(self._charm, relation_name=self._endpoints["logging"])
 
         # Provide ability for this to be scraped by Prometheus using prometheus_scrape
         refresh_events = [self._charm.on.update_status, self.cluster.on.changed]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -54,7 +54,7 @@ check_libs_installed(
 
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
-from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer, LogForwarder
+from charms.loki_k8s.v1.loki_push_api import LogForwarder, LokiPushApiConsumer
 from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
     KubernetesComputeResourcesPatch,
     adjust_resource_requirements,


### PR DESCRIPTION
## Issue
Although coordinator was passing loki endpoints to workers, it wasn't sending its own workload logs.


## Solution
Add a `LogForwarder` instance for sending nginx logs.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Pack one of the coordinator charms (I tested with tempo-coordinator-k8s) with the following changes:

requirements.txt:
```
# lib/charms/prometheus_k8s/v0/prometheus_scrape.py
cosl@git+https://github.com/canonical/cos-lib.git@coordinator-log-forwarder
```

charmcraft.yaml:
```
parts:
  charm:
    build-packages:
      - "git"
```

Then deploy the following bundle:
```
bundle: kubernetes
applications:
  alertmanager:
    charm: alertmanager-k8s
    channel: latest/edge
    revision: 135
    base: ubuntu@20.04/stable
    resources:
      alertmanager-image: 98
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  catalogue:
    charm: catalogue-k8s
    channel: latest/edge
    revision: 63
    base: ubuntu@20.04/stable
    resources:
      catalogue-image: 34
    scale: 1
    options:
      description: "Canonical Observability Stack Lite, or COS Lite, is a light-weight,
        highly-integrated, \nJuju-based observability suite running on Kubernetes.\n"
      tagline: Model-driven Observability Stack deployed with a single command.
      title: Canonical Observability Stack
    constraints: arch=amd64
    trust: true
  grafana:
    charm: grafana-k8s
    channel: latest/edge
    revision: 119
    base: ubuntu@20.04/stable
    resources:
      grafana-image: 70
      litestream-image: 45
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: latest/edge
    revision: 172
    base: ubuntu@20.04/stable
    resources:
      loki-image: 100
      node-exporter-image: 3
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  minio:
    charm: minio
    channel: latest/edge
    revision: 376
    base: ubuntu@20.04/stable
    resources:
      oci-image: 545
    scale: 1
    options:
      access-key: accesskey
      secret-key: secretkey
    constraints: arch=amd64
    storage:
      minio-data: kubernetes,1,10240M
    trust: true
  prometheus:
    charm: prometheus-k8s
    channel: latest/edge
    revision: 212
    base: ubuntu@20.04/stable
    resources:
      prometheus-image: 150
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  s3:
    charm: s3-integrator
    channel: latest/edge
    revision: 59
    scale: 1
    options:
      bucket: tempo
      endpoint: minio-0.minio-endpoints.test-nginx-logs.svc.cluster.local:9000
    constraints: arch=amd64
    trust: true
  tempo-coordinator-k8s:
    charm: local:tempo-coordinator-k8s-1
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  tempo-worker-k8s:
    charm: tempo-worker-k8s
    channel: latest/edge
    revision: 34
    resources:
      tempo-image: 3
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 211
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 161
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:ingress-per-unit
  - prometheus:ingress
- - traefik:ingress-per-unit
  - loki:ingress
- - traefik:traefik-route
  - grafana:ingress
- - traefik:ingress
  - alertmanager:ingress
- - prometheus:alertmanager
  - alertmanager:alerting
- - grafana:grafana-source
  - prometheus:grafana-source
- - grafana:grafana-source
  - loki:grafana-source
- - grafana:grafana-source
  - alertmanager:grafana-source
- - loki:alertmanager
  - alertmanager:alerting
- - prometheus:metrics-endpoint
  - traefik:metrics-endpoint
- - prometheus:metrics-endpoint
  - alertmanager:self-metrics-endpoint
- - prometheus:metrics-endpoint
  - loki:metrics-endpoint
- - prometheus:metrics-endpoint
  - grafana:metrics-endpoint
- - grafana:grafana-dashboard
  - loki:grafana-dashboard
- - grafana:grafana-dashboard
  - prometheus:grafana-dashboard
- - grafana:grafana-dashboard
  - alertmanager:grafana-dashboard
- - catalogue:ingress
  - traefik:ingress
- - catalogue:catalogue
  - grafana:catalogue
- - catalogue:catalogue
  - prometheus:catalogue
- - catalogue:catalogue
  - alertmanager:catalogue
- - catalogue:catalogue
  - loki:catalogue
- - loki:logging
  - traefik:logging
- - minio:grafana-dashboard
  - grafana:grafana-dashboard
- - minio:metrics-endpoint
  - prometheus:metrics-endpoint
- - traefik:grafana-dashboard
  - grafana:grafana-dashboard
- - loki:logging
  - tempo-coordinator-k8s:logging
- - prometheus:receive-remote-write
  - tempo-coordinator-k8s:send-remote-write
- - s3:s3-credentials
  - tempo-coordinator-k8s:s3
- - tempo-coordinator-k8s:tracing
  - alertmanager:tracing
- - tempo-coordinator-k8s:tracing
  - catalogue:tracing
- - tempo-coordinator-k8s:grafana-dashboard
  - grafana:grafana-dashboard
- - tempo-coordinator-k8s:grafana-source
  - grafana:grafana-source
- - tempo-coordinator-k8s:tracing
  - grafana:tracing
- - tempo-coordinator-k8s:tracing
  - loki:tracing
- - tempo-coordinator-k8s:metrics-endpoint
  - prometheus:metrics-endpoint
- - tempo-coordinator-k8s:tracing
  - prometheus:tracing
- - tempo-coordinator-k8s:tempo-cluster
  - tempo-worker-k8s:tempo-cluster
- - tempo-coordinator-k8s:tracing
  - traefik:tracing
- - traefik:traefik-route
  - tempo-coordinator-k8s:ingress
```

Observe that nginx logs appear in Loki.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
