### PR TITLE
Add guard against coordinator publishing worker config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.41"
+version = "0.0.42"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -273,7 +273,6 @@ class Coordinator(ops.Object):
             key="coordinator-server-cert",
             # update certificate with new SANs whenever a worker is added/removed
             sans=[self.hostname, *self.cluster.gather_addresses()],
-            refresh_events=[self.cluster.on.changed],
         )
 
         self.s3_requirer = S3Requirer(self._charm, self._endpoints["s3"])

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -90,11 +90,11 @@ class S3ConnectionInfo(pydantic.BaseModel):
 
     endpoint: str
     bucket: str
-    access_key: str = pydantic.Field(alias="access-key")
-    secret_key: str = pydantic.Field(alias="secret-key")
+    access_key: str = pydantic.Field(alias="access-key")  # type: ignore
+    secret_key: str = pydantic.Field(alias="secret-key")  # type: ignore
 
     region: Optional[str] = pydantic.Field(None)
-    tls_ca_chain: Optional[List[str]] = pydantic.Field(None, alias="tls-ca-chain")
+    tls_ca_chain: Optional[List[str]] = pydantic.Field(None, alias="tls-ca-chain")  # type: ignore
 
     @property
     def ca_cert(self) -> Optional[str]:

--- a/src/cosl/coordinated_workers/interface.py
+++ b/src/cosl/coordinated_workers/interface.py
@@ -287,10 +287,7 @@ class ClusterProvider(Object):
     ) -> None:
         """Publish the config to all related worker clusters."""
         for relation in self._relations:
-            if relation:
-                if not self._has_worker_published(relation):
-                    log.debug("Worker %s hasn't yet published its data", relation.app.name)
-                    continue
+            if relation and self._remote_data_ready(relation):
                 local_app_databag = ClusterProviderAppData(
                     worker_config=worker_config,
                     loki_endpoints=loki_endpoints,
@@ -406,7 +403,7 @@ class ClusterProvider(Object):
             return address_set.pop()
         return None
 
-    def _has_worker_published(self, relation: ops.Relation) -> bool:
+    def _remote_data_ready(self, relation: ops.Relation) -> bool:
         """Verify that each worker unit and the worker leader have published their data to the cluster relation.
 
         - unit address is published


### PR DESCRIPTION
## Issue
A coordinator should not publish the config to a worker if a worker has not yet published its own data (like roles and addresses).

## Solution
Add a guard to check if the worker has already published its data right before we try and send the config to that worker.

