### PR TITLE
Use pebble notices instead of retrying until the workload is up.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.42"
+version = "0.0.43"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -268,7 +268,7 @@ class Worker(ops.Object):
                         # Fire the pebble notice when pebble "ready" check reports "up".
                         # The assumption here is that pebble "ready" check would keep reporting "up"
                         # until it witnesses 3 consecutive failures, where 3 is set by the "threshold" field in the check layer.
-                        # So, we wait for 30 seconds before checking if its up so that we gurantee that the check is
+                        # So, we wait for 30 seconds before checking if its up so that we guarantee that the check is
                         # reporting the correct status.
                         "command": f"""bash -c 'while true; do sleep 30; /charm/bin/pebble checks ready | grep up &&
                                    /charm/bin/pebble notify {self.ready_notice_key} ||

--- a/tests/test_coordinated_workers/conftest.py
+++ b/tests/test_coordinated_workers/conftest.py
@@ -22,18 +22,6 @@ def patch_all(tmp_path: Path):
                 new=tenacity.stop_after_delay(1),
             )
         )
-        stack.enter_context(
-            patch(
-                "cosl.coordinated_workers.worker.Worker.SERVICE_STATUS_UP_RETRY_WAIT",
-                new=tenacity.wait_none(),
-            )
-        )
-        stack.enter_context(
-            patch(
-                "cosl.coordinated_workers.worker.Worker.SERVICE_STATUS_UP_RETRY_STOP",
-                new=tenacity.stop_after_delay(1),
-            )
-        )
 
         # Prevent the worker's _update_tls_certificates method to try and write our local filesystem
         stack.enter_context(

--- a/tests/test_coordinated_workers/test_worker.py
+++ b/tests/test_coordinated_workers/test_worker.py
@@ -243,6 +243,8 @@ def test_worker_does_not_restart_external_services(tmp_path):
         # layer bar services is unchanged
         "bar": ServiceStatus.ACTIVE,
         "baz": ServiceStatus.INACTIVE,
+        # workload-ready service will be added regardless
+        "workload-ready": ServiceStatus.ACTIVE,
     }
 
 

--- a/tests/test_coordinated_workers/test_worker_status.py
+++ b/tests/test_coordinated_workers/test_worker_status.py
@@ -1,9 +1,8 @@
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from functools import partial
 from unittest.mock import MagicMock, patch
 
 import pytest
-import tenacity
 from ops import ActiveStatus, CharmBase, Framework, WaitingStatus
 from ops.pebble import Layer
 from scenario import Container, Context, ExecOutput, Relation, State
@@ -38,24 +37,6 @@ def k8s_patch(status=ActiveStatus(), is_ready=True):
             is_ready=MagicMock(return_value=is_ready),
         ) as patcher:
             yield patcher
-
-
-@pytest.fixture(autouse=True)
-def patch_status_wait():
-    with ExitStack() as stack:
-        # so we don't have to wait for minutes:
-        stack.enter_context(
-            patch(
-                "cosl.coordinated_workers.worker.Worker.SERVICE_STATUS_UP_RETRY_WAIT",
-                new=tenacity.wait_none(),
-            )
-        )
-        stack.enter_context(
-            patch(
-                "cosl.coordinated_workers.worker.Worker.SERVICE_STATUS_UP_RETRY_STOP",
-                new=tenacity.stop_after_delay(2),
-            )
-        )
 
 
 @pytest.fixture

--- a/tests/test_coordinated_workers/test_worker_status.py
+++ b/tests/test_coordinated_workers/test_worker_status.py
@@ -149,22 +149,6 @@ def test_status_check_no_pebble(ctx, base_state, caplog):
 
 
 @k8s_patch()
-def test_status_check_no_config(ctx, base_state, caplog):
-    state = base_state.with_can_connect("workload", True)
-    # GIVEN there is no config file on disk
-    # WHEN we run any event
-    with patch(
-        "cosl.coordinated_workers.worker.Worker._running_worker_config", new=lambda _: None
-    ):
-        state_out = ctx.run("update_status", state)
-
-    # THEN the charm sets blocked
-    assert state_out.unit_status == WaitingStatus("Waiting for coordinator to publish a config")
-    # AND THEN the charm logs that the config isn't on disk
-    assert "Config file not on disk. Skipping status check." in caplog.messages
-
-
-@k8s_patch()
 def test_status_check_starting(ctx, base_state, tls):
     # GIVEN getting the status returns "Starting: X"
     with endpoint_starting(tls):


### PR DESCRIPTION
## Issue
We have extra complexity of adding retries using `tenacity` to wait until the workload is `ready`. We also block the hook execution queue until its up or we've exhausted all retries.

## Solution
A better solution would be to replace the retry logic with pebble notices to unblock the hook execution and be notified with a custom pebble notice event when our workload is up. Then, we could reflect that in our charm's status.

We'll define a pebble service `workload-ready` that is disabled by default. When we try to start/restart the pebble workload service, we'll also start the `workload-ready` service. What that will do is keep trying to ping our pebble check `ready` which will report if the workload is ready or not. Once that is up, `workload-ready` will fire a pebble notice which will be observed by our worker to stop that service (to prevent a continuous unnecessary loop of "up" notices). 


## Future enhancements
Currently, the way we implement notices is to notify that the workload is up after it has started, but doesn't fire notices when the workload goes down. 

## Testing Considerations
1. `git clone https://github.com/canonical/tempo-worker-k8s-operator.git`
2. `git clone https://github.com/canonical/tempo-coordinator-k8s-operator.git`
3. `cd tempo-worker-k8s-operator`
4. in `requirements.txt`, replace `cosl>=xx` with `cosl@git+https://github.com/canonical/cos-lib@OPENG-2871`
5. add `git` as part of the `build-packages` in `charmcraft.yaml`
6. `charmcraft pack`
7. cd `tempo-coordinator-k8s-operator`
8. run `TEMPO_WORKER_CHARM=/path/to/tempo-worker-k8s_ubuntu-22.04-amd64.charm tox -vve integration`
