### PR TITLE
Add `workload_tracing_protocols` as an arg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.42"
+version = "0.0.43"
 authors = [
   { name="sed-i", email="82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -303,7 +303,7 @@ class Coordinator(ops.Object):
         self.charm_tracing = TracingEndpointRequirer(
             self._charm,
             relation_name=self._endpoints["charm-tracing"],
-            protocols=["otlp_http", "jaeger_thrift_http"],
+            protocols=["otlp_http"],
         )
         self.workload_tracing = TracingEndpointRequirer(
             self._charm,

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -61,7 +61,7 @@ from charms.observability_libs.v0.kubernetes_compute_resources_patch import (
 )
 from charms.observability_libs.v1.cert_handler import VAULT_SECRET_LABEL, CertHandler
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer, ReceiverProtocol
+from charms.tempo_coordinator_k8s.v0.tracing import ReceiverProtocol, TracingEndpointRequirer
 from lightkube.models.core_v1 import ResourceRequirements
 
 logger = logging.getLogger(__name__)

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -257,7 +257,7 @@ class Coordinator(ops.Object):
         self._container_name = container_name
         self._resources_limit_options = resources_limit_options or {}
         self.remote_write_endpoints_getter = remote_write_endpoints
-        self._tracing_receivers = tracing_receivers 
+        self._tracing_receivers = tracing_receivers
 
         self.nginx = Nginx(
             self._charm,

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -302,7 +302,7 @@ class Coordinator(ops.Object):
         self.tracing = TracingEndpointRequirer(
             self._charm,
             relation_name=self._endpoints["tracing"],
-            protocols=["otlp_http"],
+            protocols=["otlp_http", "jaeger_thrift_http"],
         )
 
         # Resources patch

--- a/src/cosl/coordinated_workers/interface.py
+++ b/src/cosl/coordinated_workers/interface.py
@@ -182,8 +182,10 @@ class ClusterProviderAppData(DatabagModel):
     ### self-monitoring stuff
     loki_endpoints: Optional[Dict[str, str]] = None
     """Endpoints to which the workload (and the worker charm) can push logs to."""
-    tracing_receivers: Optional[Dict[str, str]] = None
-    """Endpoints to which the workload (and the worker charm) can push traces to."""
+    charm_tracing_receivers: Optional[Dict[str, str]] = None
+    """Endpoints to which the the worker charm can push charm traces to."""
+    workload_tracing_receivers: Optional[Dict[str, str]] = None
+    """Endpoints to which the the worker can push workload traces to."""
     remote_write_endpoints: Optional[List[RemoteWriteEndpoint]] = None
     """Endpoints to which the workload (and the worker charm) can push metrics to."""
 
@@ -282,7 +284,8 @@ class ClusterProvider(Object):
         s3_tls_ca_chain: Optional[str] = None,
         privkey_secret_id: Optional[str] = None,
         loki_endpoints: Optional[Dict[str, str]] = None,
-        tracing_receivers: Optional[Dict[str, str]] = None,
+        charm_tracing_receivers: Optional[Dict[str, str]] = None,
+        workload_tracing_receivers: Optional[Dict[str, str]] = None,
         remote_write_endpoints: Optional[List[RemoteWriteEndpoint]] = None,
     ) -> None:
         """Publish the config to all related worker clusters."""
@@ -294,7 +297,8 @@ class ClusterProvider(Object):
                     ca_cert=ca_cert,
                     server_cert=server_cert,
                     privkey_secret_id=privkey_secret_id,
-                    tracing_receivers=tracing_receivers,
+                    charm_tracing_receivers=charm_tracing_receivers,
+                    workload_tracing_receivers=workload_tracing_receivers,
                     remote_write_endpoints=remote_write_endpoints,
                     s3_tls_ca_chain=s3_tls_ca_chain,
                 )
@@ -573,11 +577,18 @@ class ClusterRequirer(Object):
             s3_tls_ca_chain=data.s3_tls_ca_chain,
         )
 
-    def get_tracing_receivers(self) -> Dict[str, str]:
-        """Fetch the tracing receivers from the coordinator databag."""
+    def get_charm_tracing_receivers(self) -> Dict[str, str]:
+        """Fetch the charm tracing receivers from the coordinator databag."""
         data = self._get_data_from_coordinator()
         if data:
-            return data.tracing_receivers or {}
+            return data.charm_tracing_receivers or {}
+        return {}
+
+    def get_workload_tracing_receivers(self) -> Dict[str, str]:
+        """Fetch the workload tracing receivers from the coordinator databag."""
+        data = self._get_data_from_coordinator()
+        if data:
+            return data.workload_tracing_receivers or {}
         return {}
 
     def get_remote_write_endpoints(self) -> List[RemoteWriteEndpoint]:

--- a/src/cosl/coordinated_workers/interface.py
+++ b/src/cosl/coordinated_workers/interface.py
@@ -573,7 +573,7 @@ class ClusterRequirer(Object):
             s3_tls_ca_chain=data.s3_tls_ca_chain,
         )
 
-    def get_tracing_receivers(self) -> Optional[Dict[str, str]]:
+    def get_tracing_receivers(self) -> Dict[str, str]:
         """Fetch the tracing receivers from the coordinator databag."""
         data = self._get_data_from_coordinator()
         if data:

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -4,6 +4,7 @@
 """Workload manager for Nginx. Used by the coordinator to load-balance and group the workers."""
 
 import logging
+from pathlib import Path
 from typing import Callable, Optional, TypedDict
 
 from ops import CharmBase, pebble
@@ -83,6 +84,11 @@ class Nginx:
             self._container.push(KEY_PATH, private_key, make_dirs=True)
             self._container.push(CERT_PATH, server_cert, make_dirs=True)
             self._container.push(CA_CERT_PATH, ca_cert, make_dirs=True)
+
+            # push CA cert to charm container
+            Path(CA_CERT_PATH).mkdir(parents=True, exist_ok=True)
+            Path(CA_CERT_PATH).write_text(ca_cert)
+
             # FIXME: uncomment as soon as the nginx image contains the ca-certificates package
             # self._container.exec(["update-ca-certificates", "--fresh"])
 
@@ -95,6 +101,8 @@ class Nginx:
                 self._container.remove_path(KEY_PATH, recursive=True)
             if self._container.exists(CA_CERT_PATH):
                 self._container.remove_path(CA_CERT_PATH, recursive=True)
+            if Path(CA_CERT_PATH).exists():
+                Path(CA_CERT_PATH).unlink(missing_ok=True)
             # FIXME: uncomment as soon as the nginx image contains the ca-certificates package
             # self._container.exec(["update-ca-certificates", "--fresh"])
 

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -86,7 +86,7 @@ class Nginx:
             self._container.push(CA_CERT_PATH, ca_cert, make_dirs=True)
 
             # push CA cert to charm container
-            Path(CA_CERT_PATH).mkdir(parents=True, exist_ok=True)
+            Path(CA_CERT_PATH).parent.mkdir(parents=True, exist_ok=True)
             Path(CA_CERT_PATH).write_text(ca_cert)
 
             # FIXME: uncomment as soon as the nginx image contains the ca-certificates package

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -722,7 +722,7 @@ class Worker(ops.Object):
         >>>         self.worker = Worker(...)
         >>>         self.my_endpoint, self.cert_path = self.worker.charm_tracing_config()
         """
-        receivers = self.cluster.get_tracing_receivers()
+        receivers = self.cluster.get_charm_tracing_receivers()
 
         if not receivers:
             return None, None

--- a/tests/test_coordinated_workers/test_coordinator.py
+++ b/tests/test_coordinated_workers/test_coordinator.py
@@ -20,7 +20,8 @@ def coordinator_state():
         for endpoint, interface in {
             "my-certificates": {"interface": "certificates"},
             "my-logging": {"interface": "loki_push_api"},
-            "my-tracing": {"interface": "tracing"},
+            "my-charm-tracing": {"interface": "tracing"},
+            "my-workload-tracing": {"interface": "tracing"},
         }.items()
     }
     requires_relations["my-s3"] = Relation(
@@ -75,7 +76,8 @@ def coordinator_charm(request):
                 "my-certificates": {"interface": "certificates"},
                 "my-cluster": {"interface": "cluster"},
                 "my-logging": {"interface": "loki_push_api"},
-                "my-tracing": {"interface": "tracing", "limit": 1},
+                "my-charm-tracing": {"interface": "tracing", "limit": 1},
+                "my-workload-tracing": {"interface": "tracing", "limit": 1},
                 "my-s3": {"interface": "s3"},
             },
             "provides": {
@@ -116,7 +118,8 @@ def coordinator_charm(request):
                     "grafana-dashboards": "my-dashboards",
                     "logging": "my-logging",
                     "metrics": "my-metrics",
-                    "tracing": "my-tracing",
+                    "charm-tracing": "my-charm-tracing",
+                    "workload-tracing": "my-workload-tracing",
                     "s3": "my-s3",
                 },
                 nginx_config=lambda coordinator: f"nginx configuration for {coordinator._charm.meta.name}",

--- a/tests/test_coordinated_workers/test_coordinator.py
+++ b/tests/test_coordinated_workers/test_coordinator.py
@@ -75,7 +75,7 @@ def coordinator_charm(request):
                 "my-certificates": {"interface": "certificates"},
                 "my-cluster": {"interface": "cluster"},
                 "my-logging": {"interface": "loki_push_api"},
-                "my-tracing": {"interface": "tracing"},
+                "my-tracing": {"interface": "tracing", "limit": 1},
                 "my-s3": {"interface": "s3"},
             },
             "provides": {

--- a/tests/test_coordinated_workers/test_coordinator.py
+++ b/tests/test_coordinated_workers/test_coordinator.py
@@ -258,8 +258,8 @@ def test_tracing_receivers_urls(coordinator_state: State, coordinator_charm: ops
         remote_app_data={
             "receivers": json.dumps(
                 [
-                    {"protocol": {"name": "otlp_http", "type": "http"}, "url": "1.2.3.4:4318"},
-                    {"protocol": {"name": "otlp_grpc", "type": "grpc"}, "url": "1.2.3.4:4317"},
+                    {"protocol": {"name": "otlp_http", "type": "http"}, "url": "5.6.7.8:4318"},
+                    {"protocol": {"name": "otlp_grpc", "type": "grpc"}, "url": "5.6.7.8:4317"},
                 ]
             )
         },
@@ -272,8 +272,10 @@ def test_tracing_receivers_urls(coordinator_state: State, coordinator_charm: ops
         ),
     ) as mgr:
         coordinator: Coordinator = mgr.charm.coordinator
-        expected_result = {
+        assert coordinator._charm_tracing_receivers_urls == {
             "otlp_http": "1.2.3.4:4318",
-            "otlp_grpc": "1.2.3.4:4317",
         }
-        assert coordinator._tracing_receivers_urls == expected_result
+        assert coordinator._workload_tracing_receivers_urls == {
+            "otlp_http": "5.6.7.8:4318",
+            "otlp_grpc": "5.6.7.8:4317",
+        }

--- a/tests/test_coordinated_workers/test_coordinator_status.py
+++ b/tests/test_coordinated_workers/test_coordinator_status.py
@@ -37,7 +37,7 @@ class MyCoordCharm(CharmBase):
                 "logging": "logging",
                 "metrics": "metrics-endpoint",
                 "charm-tracing": "self-charm-tracing",
-                "workload-tracing": "self-workload-tracing"
+                "workload-tracing": "self-workload-tracing",
             },
             nginx_config=lambda _: "nginx config",
             workers_config=lambda _: "worker config",

--- a/tests/test_coordinated_workers/test_coordinator_status.py
+++ b/tests/test_coordinated_workers/test_coordinator_status.py
@@ -36,7 +36,8 @@ class MyCoordCharm(CharmBase):
                 "grafana-dashboards": "grafana-dashboard",
                 "logging": "logging",
                 "metrics": "metrics-endpoint",
-                "tracing": "self-tracing",
+                "charm-tracing": "self-charm-tracing",
+                "workload-tracing": "self-workload-tracing"
             },
             nginx_config=lambda _: "nginx config",
             workers_config=lambda _: "worker config",
@@ -61,7 +62,8 @@ def ctx(coord_charm):
                 "s3": {"interface": "s3"},
                 "logging": {"interface": "loki_push_api"},
                 "certificates": {"interface": "tls-certificates"},
-                "self-tracing": {"interface": "tracing", "limit": 1},
+                "self-charm-tracing": {"interface": "tracing", "limit": 1},
+                "self-workload-tracing": {"interface": "tracing", "limit": 1},
             },
             "provides": {
                 "cluster": {"interface": "cluster"},

--- a/tests/test_coordinated_workers/test_coordinator_status.py
+++ b/tests/test_coordinated_workers/test_coordinator_status.py
@@ -61,7 +61,7 @@ def ctx(coord_charm):
                 "s3": {"interface": "s3"},
                 "logging": {"interface": "loki_push_api"},
                 "certificates": {"interface": "tls-certificates"},
-                "self-tracing": {"interface": "tracing"},
+                "self-tracing": {"interface": "tracing", "limit": 1},
             },
             "provides": {
                 "cluster": {"interface": "cluster"},


### PR DESCRIPTION
## Issue
Loki and Mimir's workload traces are configured using `jaeger_thrift_http` protocol.

## Solution
Add an optional list `workload_tracing_protocols` to enable coordinators to pass a list of workload protocols they want to receive endpoints to be used by their workers' workloads for tracing.

## Drive-bys
- Split `charm_tracing` and `workload_tracing` into 2 separate endpoints.
- Push CA cert into charm container when nginx TLS is configured
