### PR TITLE
Add ConnectionResetError(ConnectionError) for debug logging

### DIFF
--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -311,9 +311,10 @@ class Worker(ops.Object):
             return ServiceEndpointStatus.starting
 
         except (HTTPError, ConnectionResetError) as e:
-            logger.debug("Error getting readiness endpoint: server not up (yet): %s", e)
-        except Exception:
-            logger.exception("Unexpected exception getting readiness endpoint")
+            logger.debug(f"Error getting readiness endpoint: server not up (yet): {e}")
+        except Exception as e:
+            logger.exception(f"Unexpected exception getting readiness endpoint: {e}")
+
         return ServiceEndpointStatus.down
 
     def _on_collect_status(self, e: ops.CollectStatusEvent):

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -310,8 +310,10 @@ class Worker(ops.Object):
             logger.debug(f"GET {check_endpoint} returned: {raw_out!r}.")
             return ServiceEndpointStatus.starting
 
-        except (HTTPError, ConnectionResetError) as e:
-            logger.debug(f"Error getting readiness endpoint: server not up (yet): {e}")
+        except HTTPError as e:
+            logger.debug(f"Error getting readiness endpoint, server not up (yet): {e}")
+        except ConnectionResetError as e:
+            logger.debug(f"Error getting readiness endpoint, does the specified bucket exist?: {e}")
         except Exception as e:
             logger.exception(f"Unexpected exception getting readiness endpoint: {e}")
 

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -313,7 +313,9 @@ class Worker(ops.Object):
         except HTTPError as e:
             logger.debug(f"Error getting readiness endpoint, server not up (yet): {e}")
         except ConnectionResetError as e:
-            logger.warning(f"Error getting readiness endpoint (check the workload container logs for details): {e}")
+            logger.warning(
+                f"Error getting readiness endpoint (check the workload container logs for details): {e}"
+            )
         except Exception as e:
             logger.exception(f"Unexpected exception getting readiness endpoint: {e}")
 

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -313,7 +313,7 @@ class Worker(ops.Object):
         except HTTPError as e:
             logger.debug(f"Error getting readiness endpoint, server not up (yet): {e}")
         except ConnectionResetError as e:
-            logger.debug(f"Error getting readiness endpoint, does the specified bucket exist?: {e}")
+            logger.warning(f"Error getting readiness endpoint (check the workload container logs for details): {e}")
         except Exception as e:
             logger.exception(f"Unexpected exception getting readiness endpoint: {e}")
 

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -310,8 +310,8 @@ class Worker(ops.Object):
             logger.debug(f"GET {check_endpoint} returned: {raw_out!r}.")
             return ServiceEndpointStatus.starting
 
-        except HTTPError:
-            logger.debug("Error getting readiness endpoint: server not up (yet)")
+        except (HTTPError, ConnectionResetError) as e:
+            logger.debug("Error getting readiness endpoint: server not up (yet): %s", e)
         except Exception:
             logger.exception("Unexpected exception getting readiness endpoint")
         return ServiceEndpointStatus.down


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
When trying to deploy microservice Mimir with (and without) TF and the bucket in minio is not found, unhelpful tracebacks are found in the Juju debug logs.

```
unit-mimir-read-0: 10:31:31 ERROR unit.mimir-read/0.juju-log mimir-cluster:17: Unexpected exception getting readiness endpoint
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mimir-read-0/charm/venv/cosl/coordinated_workers/worker.py", line 291, in check_readiness
    with urllib.request.urlopen(check_endpoint(self)) as response:
  File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  ...
  File "/usr/lib/python3.10/socket.py", line 705, in readinto
    return self._sock.recv_into(b)
ConnectionResetError: [Errno 104] Connection reset by peer
```
A **ConnectionResetError** is raised and seems to indicate some networking issue. However if we check the workload container logs with `kubectl -n mimir logs pods/mimir-read-0 -c mimir` we can see that the issue originates from the bucket not being found:
```
2024-11-12T18:16:01.518Z [mimir] ts=2024-11-12T18:16:01.448602423Z caller=seed.go:127 level=warn msg="failed to read cluster seed file from object storage" err="The specified bucket does not exist"
```

## Solution
<!-- A summary of the solution addressing the above issue -->
Ensure the ConnectionResetError is caught and the initial issue is **communicated to the user** without resorting to Traceback.

We could for example change the log to be:

```
unit-mimir-read-0: 15:33:56 DEBUG unit.mimir-read/0.juju-log mimir-cluster:5: Error getting readiness endpoint, does the specified bucket exist?: [Errno 104] Connection reset by peer
```

which hints the user to check the bucket exists. Although, ConnectionResetError does **not always** mean there is a bucket not found.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- Following the [manual steps to deploy S3](https://github.com/canonical/observability/pull/219/files#diff-f428aad8b8ffe7b9d315598b458d11be35b786325981f5464e5c06697398350fR102) is the (current) intended approach to deploy COS with TF locally.
- We can intentionally omit the command to create the bucket, reproducing the issue
  - Omit this -> `juju ssh minio/leader /root/minio/mc mb local/mimir;`


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
This is not a breaking change and only affects logging of the worker charms.