### PR TITLE
Add dashboard uid generation helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.49"
+version = "0.0.50"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/__init__.py
+++ b/src/cosl/__init__.py
@@ -4,7 +4,7 @@
 """Utils for observability Juju charms."""
 
 from .cos_tool import CosTool
-from .grafana_dashboard import GrafanaDashboard, LZMABase64, generate_dashboard_uid
+from .grafana_dashboard import GrafanaDashboard, LZMABase64, DashboardPath40UID
 from .juju_topology import JujuTopology
 from .mandatory_relation_pairs import MandatoryRelationPairs
 from .rules import AlertRules, RecordingRules
@@ -14,7 +14,7 @@ __all__ = [
     "CosTool",
     "GrafanaDashboard",
     "LZMABase64",
-    "generate_dashboard_uid",
+    "DashboardPath40UID",
     "AlertRules",
     "RecordingRules",
     "MandatoryRelationPairs",

--- a/src/cosl/__init__.py
+++ b/src/cosl/__init__.py
@@ -4,7 +4,7 @@
 """Utils for observability Juju charms."""
 
 from .cos_tool import CosTool
-from .grafana_dashboard import GrafanaDashboard, LZMABase64, DashboardPath40UID
+from .grafana_dashboard import DashboardPath40UID, GrafanaDashboard, LZMABase64
 from .juju_topology import JujuTopology
 from .mandatory_relation_pairs import MandatoryRelationPairs
 from .rules import AlertRules, RecordingRules

--- a/src/cosl/__init__.py
+++ b/src/cosl/__init__.py
@@ -4,7 +4,7 @@
 """Utils for observability Juju charms."""
 
 from .cos_tool import CosTool
-from .grafana_dashboard import GrafanaDashboard
+from .grafana_dashboard import GrafanaDashboard, generate_dashboard_uid
 from .juju_topology import JujuTopology
 from .mandatory_relation_pairs import MandatoryRelationPairs
 from .rules import AlertRules, RecordingRules
@@ -13,6 +13,7 @@ __all__ = [
     "JujuTopology",
     "CosTool",
     "GrafanaDashboard",
+    "generate_dashboard_uid",
     "AlertRules",
     "RecordingRules",
     "MandatoryRelationPairs",

--- a/src/cosl/__init__.py
+++ b/src/cosl/__init__.py
@@ -4,7 +4,7 @@
 """Utils for observability Juju charms."""
 
 from .cos_tool import CosTool
-from .grafana_dashboard import GrafanaDashboard, generate_dashboard_uid
+from .grafana_dashboard import GrafanaDashboard, LZMABase64, generate_dashboard_uid
 from .juju_topology import JujuTopology
 from .mandatory_relation_pairs import MandatoryRelationPairs
 from .rules import AlertRules, RecordingRules
@@ -13,6 +13,7 @@ __all__ = [
     "JujuTopology",
     "CosTool",
     "GrafanaDashboard",
+    "LZMABase64",
     "generate_dashboard_uid",
     "AlertRules",
     "RecordingRules",

--- a/src/cosl/grafana_dashboard.py
+++ b/src/cosl/grafana_dashboard.py
@@ -9,6 +9,7 @@ import json
 import logging
 import lzma
 from typing import Any, Dict, Union
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +23,11 @@ class GrafanaDashboard(str):
 
     @staticmethod
     def _serialize(raw_json: Union[str, bytes]) -> "GrafanaDashboard":
+        warnings.warn("GrafanaDashboard._serialize is deprecated; use LZMABase64.compress(json.dumps(...)) instead.", category=DeprecationWarning)
         return GrafanaDashboard(LZMABase64.compress(raw_json))
 
     def _deserialize(self) -> Dict[str, Any]:
+        warnings.warn("GrafanaDashboard._deserialize is deprecated; use json.loads(LZMABase64.decompress(...)) instead.", category=DeprecationWarning)
         try:
             return json.loads(LZMABase64.decompress(self))
         except json.decoder.JSONDecodeError as e:

--- a/src/cosl/grafana_dashboard.py
+++ b/src/cosl/grafana_dashboard.py
@@ -8,8 +8,8 @@ import hashlib
 import json
 import logging
 import lzma
-from typing import Any, Dict, Union
 import warnings
+from typing import Any, Dict, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +23,17 @@ class GrafanaDashboard(str):
 
     @staticmethod
     def _serialize(raw_json: Union[str, bytes]) -> "GrafanaDashboard":
-        warnings.warn("GrafanaDashboard._serialize is deprecated; use LZMABase64.compress(json.dumps(...)) instead.", category=DeprecationWarning)
+        warnings.warn(
+            "GrafanaDashboard._serialize is deprecated; use LZMABase64.compress(json.dumps(...)) instead.",
+            category=DeprecationWarning,
+        )
         return GrafanaDashboard(LZMABase64.compress(raw_json))
 
     def _deserialize(self) -> Dict[str, Any]:
-        warnings.warn("GrafanaDashboard._deserialize is deprecated; use json.loads(LZMABase64.decompress(...)) instead.", category=DeprecationWarning)
+        warnings.warn(
+            "GrafanaDashboard._deserialize is deprecated; use json.loads(LZMABase64.decompress(...)) instead.",
+            category=DeprecationWarning,
+        )
         try:
             return json.loads(LZMABase64.decompress(self))
         except json.decoder.JSONDecodeError as e:
@@ -58,7 +64,7 @@ class LZMABase64:
         return lzma.decompress(base64.b64decode(compressed.encode("utf-8"))).decode()
 
 
-def _hash(components: tuple, length: int) -> str:
+def _hash(components: Tuple[str, ...], length: int) -> str:
     return hashlib.shake_256("-".join(components).encode("utf-8")).hexdigest(length)
 
 

--- a/src/cosl/grafana_dashboard.py
+++ b/src/cosl/grafana_dashboard.py
@@ -4,12 +4,13 @@
 """Grafana Dashboard."""
 
 import base64
+import binascii
 import hashlib
 import json
 import logging
 import lzma
 import warnings
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple, Union, ClassVar
 
 logger = logging.getLogger(__name__)
 
@@ -64,27 +65,54 @@ class LZMABase64:
         return lzma.decompress(base64.b64decode(compressed.encode("utf-8"))).decode()
 
 
-def _hash(components: Tuple[str, ...], length: int) -> str:
-    return hashlib.shake_256("-".join(components).encode("utf-8")).hexdigest(length)
+class DashboardPath40UID:
+
+    length: ClassVar[int] = 40
+
+    @classmethod
+    def _hash(cls, components: Tuple[str, ...], length: int) -> str:
+        return hashlib.shake_256("-".join(components).encode("utf-8")).hexdigest(length)
+
+    @classmethod
+    def generate(cls, charm_name: str, dashboard_path: str) -> str:
+        """Generate a dashboard uid from charm name and dashboard path.
+
+        The combination of charm name and dashboard path (relative to the charm root) is guaranteed to be unique across
+        the ecosystem. By design, this intentionally does not take into account instances of the same charm with
+        different charm revisions, which could have different dashboard versions.
+        Ref: https://github.com/canonical/observability/pull/206
+
+        The max length grafana allows for a dashboard uid is 40.
+        Ref: https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#identifier-id-vs-unique-identifier-uid
+
+        Args:
+            charm_name: The name of the charm (not app!) that owns the dashboard.
+            dashboard_path: Path (relative to charm root) to the dashboard file.
+
+        Returns: A uid based on the input args.
+        """
+        # Since the digest is bytes, we need to convert it to a charset that grafana accepts.
+        # Let's use hexdigest, which means 2 chars per byte, reducing our effective digest size to 20.
+        return cls._hash((charm_name, dashboard_path), cls.length // 2)
+
+    @classmethod
+    def is_valid(cls, uid: str) -> bool:
+        """Check if the given UID is a valid "Path-40" UID.
+
+        The UID must be of a particular length, and since we generate it with hexdigest() then we also know it must
+        unhexlify.
+
+        This is not a bullet-proof check, because it's plausible that some dashboard would have a 40-length hexstring as
+        its uid, but given the current state of the ecosystem, it's quite unlikely.
+        """
+        if not uid:
+            return False
+        if len(uid) != cls.length:
+            return False
+        try:
+            binascii.unhexlify(uid)
+        except binascii.Error:
+            return False
+        return True
 
 
-def generate_dashboard_uid(charm_name: str, dashboard_path: str) -> str:
-    """Generate a dashboard uid from charm name and dashboard path.
-
-    The combination of charm name and dashboard path (relative to the charm root) is guaranteed to be unique across the
-    ecosystem. By design, this intentionally does not take into account instances of the same charm with different charm
-    revisions, which could have different dashboard versions.
-    Ref: https://github.com/canonical/observability/pull/206
-
-    The max length grafana allows for a dashboard uid is 40.
-    Ref: https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#identifier-id-vs-unique-identifier-uid
-
-    Args:
-        charm_name: The name of the charm (not app!) that owns the dashboard.
-        dashboard_path: Path (relative to charm root) to the dashboard file.
-
-    Returns: A uid based on the input args.
-    """
-    # Since the digest is bytes, we need to convert it to a charset that grafana accepts.
-    # Let's use hexdigest, which means 2 chars per byte, reducing our effective digest size to 20.
-    return _hash((charm_name, dashboard_path), 20)

--- a/src/cosl/grafana_dashboard.py
+++ b/src/cosl/grafana_dashboard.py
@@ -4,6 +4,7 @@
 """Grafana Dashboard."""
 
 import base64
+import hashlib
 import json
 import logging
 import lzma
@@ -37,3 +38,19 @@ class GrafanaDashboard(str):
     def __repr__(self):
         """Return string representation of self."""
         return "<GrafanaDashboard>"
+
+
+def generate_dashboard_uid(*args: str) -> str:
+    """Generate a dashboard uid from a collection of strings.
+
+    The max length grafana allows for a dashboard uid is 40.
+    Ref: https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#identifier-id-vs-unique-identifier-uid
+
+    Args:
+        args: A collection of strings used to calculate the uid.
+
+    Returns: A uid based on the input args.
+    """
+    # Since the digest is bytes, we need to convert it to a charset that grafana accepts.
+    # Let's use hexdigest, which means 2 chars per byte, reducing our effective digest size to 20.
+    return hashlib.shake_256("-".join(args).encode("utf-8")).hexdigest(20)

--- a/src/cosl/grafana_dashboard.py
+++ b/src/cosl/grafana_dashboard.py
@@ -60,7 +60,7 @@ class LZMABase64:
 
     @classmethod
     def decompress(cls, compressed: str) -> str:
-        """Decompress dashboard from base64-encoded-lzma-compressed string."""
+        """Decompress from base64-encoded-lzma-compressed string."""
         return lzma.decompress(base64.b64decode(compressed.encode("utf-8"))).decode()
 
 

--- a/src/cosl/grafana_dashboard.py
+++ b/src/cosl/grafana_dashboard.py
@@ -10,7 +10,7 @@ import json
 import logging
 import lzma
 import warnings
-from typing import Any, Dict, Tuple, Union, ClassVar
+from typing import Any, ClassVar, Dict, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,7 @@ class LZMABase64:
 
 
 class DashboardPath40UID:
+    """A helper class for dashboard UID of length 40, generated from charm name and dashboard path."""
 
     length: ClassVar[int] = 40
 
@@ -114,5 +115,3 @@ class DashboardPath40UID:
         except binascii.Error:
             return False
         return True
-
-

--- a/tests/test_grafana_dashboard.py
+++ b/tests/test_grafana_dashboard.py
@@ -4,7 +4,7 @@
 import json
 import unittest
 
-from cosl import GrafanaDashboard, generate_dashboard_uid
+from cosl import GrafanaDashboard, LZMABase64, generate_dashboard_uid
 
 
 class TestRoundTripEncDec(unittest.TestCase):
@@ -17,6 +17,14 @@ class TestRoundTripEncDec(unittest.TestCase):
             "even": [{"nested": "types", "and_integers": [42, 42]}],
         }
         self.assertDictEqual(d, GrafanaDashboard._serialize(json.dumps(d))._deserialize())
+
+
+class TestLZMABase64(unittest.TestCase):
+    """Tests the round-trip encoding/decoding of the GrafanaDashboard class."""
+
+    def test_round_trip(self):
+        s = "starting point"
+        self.assertEqual(s, LZMABase64.decompress(LZMABase64.compress(s)))
 
 
 class TestGenerateUID(unittest.TestCase):

--- a/tests/test_grafana_dashboard.py
+++ b/tests/test_grafana_dashboard.py
@@ -4,15 +4,35 @@
 import json
 import unittest
 
-from cosl import GrafanaDashboard
+from cosl import GrafanaDashboard, generate_dashboard_uid
 
 
-class TestDashboard(unittest.TestCase):
-    """Tests the GrafanaDashboard class."""
+class TestRoundTripEncDec(unittest.TestCase):
+    """Tests the round-trip encoding/decoding of the GrafanaDashboard class."""
 
-    def test_serializes_and_deserializes(self):
-        expected_output = {"msg": "this is the expected output after passing through the class."}
+    def test_round_trip(self):
+        d = {
+            "some": "dict",
+            "with": "keys",
+            "even": [{"nested": "types", "and_integers": [42, 42]}],
+        }
+        self.assertDictEqual(d, GrafanaDashboard._serialize(json.dumps(d))._deserialize())
 
-        dash = GrafanaDashboard._serialize(json.dumps(expected_output))
 
-        assert dash._deserialize() == expected_output
+class TestGenerateUID(unittest.TestCase):
+    """Spec for the UID generation logic."""
+
+    def test_uid_length_is_40(self):
+        self.assertEqual(40, len(generate_dashboard_uid("whatever")))
+
+    def test_collisions(self):
+        """A very naive and primitive collision check that is meant to catch trivial errors."""
+        self.assertNotEqual(
+            generate_dashboard_uid("some-charm", "dashboard1.json"),
+            generate_dashboard_uid("some-charm", "dashboard2.json"),
+        )
+
+        self.assertNotEqual(
+            generate_dashboard_uid("some-charm"),
+            generate_dashboard_uid("some-charm", "dashboard.json"),
+        )

--- a/tests/test_grafana_dashboard.py
+++ b/tests/test_grafana_dashboard.py
@@ -31,7 +31,7 @@ class TestGenerateUID(unittest.TestCase):
     """Spec for the UID generation logic."""
 
     def test_uid_length_is_40(self):
-        self.assertEqual(40, len(generate_dashboard_uid("whatever")))
+        self.assertEqual(40, len(generate_dashboard_uid("my-charm", "my-dash.json")))
 
     def test_collisions(self):
         """A very naive and primitive collision check that is meant to catch trivial errors."""
@@ -41,6 +41,6 @@ class TestGenerateUID(unittest.TestCase):
         )
 
         self.assertNotEqual(
-            generate_dashboard_uid("some-charm"),
             generate_dashboard_uid("some-charm", "dashboard.json"),
+            generate_dashboard_uid("diff-charm", "dashboard.json"),
         )

--- a/tests/test_grafana_dashboard.py
+++ b/tests/test_grafana_dashboard.py
@@ -4,7 +4,7 @@
 import json
 import unittest
 
-from cosl import GrafanaDashboard, LZMABase64, DashboardPath40UID
+from cosl import DashboardPath40UID, GrafanaDashboard, LZMABase64
 
 
 class TestRoundTripEncDec(unittest.TestCase):
@@ -52,4 +52,8 @@ class TestGenerateUID(unittest.TestCase):
         self.assertFalse(DashboardPath40UID.is_valid("non-hex string, crafted to be 40 chars!!"))
 
         self.assertTrue(DashboardPath40UID.is_valid("0" * 40))
-        self.assertTrue(DashboardPath40UID.is_valid(DashboardPath40UID.generate("some-charm", "dashboard.json")))
+        self.assertTrue(
+            DashboardPath40UID.is_valid(
+                DashboardPath40UID.generate("some-charm", "dashboard.json")
+            )
+        )


### PR DESCRIPTION
## Issue
- Currently it is not possible to auto generate dashboard uid consistently without code duplication in GrafanaDashboardProvider and COSAgentProvider. 
- The "GrafanaDashboard" class has a confusing terminology: "serialize" and "deserialize" are inconsistent.


## Solution

### New function for rendering dashboard uid

In tandem with:
- https://github.com/canonical/grafana-k8s-operator/pull/363
- https://github.com/canonical/grafana-agent-operator/pull/224
- https://github.com/canonical/grafana-agent-k8s-operator/pull/337

### Extract LZMA base64 logic from GrafanaDashboard class
Also, deprecate the GrafanaDashboard class.

The new LZMABase64 class is consistent with the following view:
```mermaid
graph LR

dict -->|serialize| json-str
json-str -->|deserialize| dict

json-str -->|compress + base64 encode| compressed-str
compressed-str -->|base64 decode + decompress| json-str
```

## Context
This change was prompted by an [ADR](https://github.com/canonical/observability/pull/206) for addressing dashboard UID collisions.


## Testing Instructions
This is an ops-independent change. See unit tests.


## Upgrade Notes
If dependent code is using `grafana_dashboard.GrafanaDashboard`, a deprecation warning will now be printed. Switch to using `LZMABase64`.
