### PR TITLE
Enable Generic Alert Rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.48"
+version = "0.0.49"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -281,7 +281,7 @@ class Rules(ABC):
 
     def _from_dict(
         self,
-        yaml_dict: Dict[str, Any],
+        rule_dict: Dict[str, Any],
         *,
         group_name: Optional[str] = None,
         group_name_prefix: Optional[str] = None,
@@ -289,30 +289,28 @@ class Rules(ABC):
         """Process rules from dict, injecting juju topology. If a single-rule format is provided, a hash of the yaml file is injected into the group name to ensure uniqueness.
 
         Args:
-            yaml_dict: rules content in single-rule or official-rule format as a YAML dict
+            rule_dict: rules content in single-rule or official-rule format as a YAML dict
             group_name: a custom identifier for the rule name to include in the group name
             group_name_prefix: a custom group identifier to prefix the resulting group name, likely Juju topology and relative path context
 
         Raises:
             ValueError, when invalid rule format given.
         """
-        # TODO _alerts_alerts is leftover code from elsewhere
-        # TODO rename this to be yaml_dict
-        if not yaml_dict:
+        if not rule_dict:
             raise ValueError("Empty")
 
-        if self._is_official_rule_format(yaml_dict):
-            groups = yaml_dict["groups"]
-        elif self._is_single_rule_format(yaml_dict, self.rule_type):
+        if self._is_official_rule_format(rule_dict):
+            groups = rule_dict["groups"]
+        elif self._is_single_rule_format(rule_dict, self.rule_type):
             if not group_name:
                 # Note: the caller of this function should ensure this never happens:
                 # Either we use the standard format, or we'd pass a group_name.
                 # If/when we drop support for the single-rule-per-file format, this won't
                 # be needed anymore.
-                group_name = hashlib.shake_256(str(yaml_dict).encode("utf-8")).hexdigest(10)
+                group_name = hashlib.shake_256(str(rule_dict).encode("utf-8")).hexdigest(10)
 
             # convert to list of groups to match official rule format
-            groups = [{"name": group_name, "rules": [yaml_dict]}]
+            groups = [{"name": group_name, "rules": [rule_dict]}]
         else:
             # invalid/unsupported
             raise ValueError("Invalid rule format")
@@ -368,19 +366,19 @@ class Rules(ABC):
 
     def add(
         self,
-        yaml_dict: Dict[str, Any],
+        rule_dict: Dict[str, Any],
         group_name: Optional[str] = None,
         group_name_prefix: Optional[str] = None,
     ) -> None:
         """Add rules from dict to the existing ruleset.
 
         Args:
-            yaml_dict: a single-rule or official-rule YAML dict
+            rule_dict: a single-rule or official-rule YAML dict
             group_name: a custom group name, used only if the new rule is of single-rule format
             group_name_prefix: a custom group name prefix, used only if the new rule is of single-rule format
         """
         self.groups.extend(
-            self._from_dict(yaml_dict, group_name=group_name, group_name_prefix=group_name_prefix)
+            self._from_dict(rule_dict, group_name=group_name, group_name_prefix=group_name_prefix)
         )
 
     def add_path(self, dir_path: Union[str, Path], *, recursive: bool = False) -> None:

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -77,7 +77,6 @@ The following labels are automatically included with each rule:
 
 import hashlib
 import logging
-import os
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -264,8 +263,8 @@ class Rules(ABC):
             # Generate group name prefix
             #  - name, from juju topology
             #  - suffix, from the relative path of the rule file;
-            rel_path = os.path.relpath(os.path.dirname(file_path), root_path)
-            rel_path = "" if rel_path == "." else rel_path.replace(os.path.sep, "_")
+            rel_path = file_path.parent.relative_to(root_path)
+            rel_path = "" if rel_path == Path(".") else rel_path.as_posix().replace("/", "_")
             group_name_parts = [self.topology.identifier] if self.topology else []
             group_name_parts.append(rel_path)
             group_name_prefix = "_".join(filter(None, group_name_parts))

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -301,7 +301,6 @@ class Rules(ABC):
             raise ValueError("Empty")
 
         if self._is_official_rule_format(yaml_str):
-            # TODO DO not cast since pyright knows its a str, we still need to
             yaml_str = yaml_str
             groups = yaml_str["groups"]
         elif self._is_single_rule_format(yaml_str, self.rule_type):
@@ -364,7 +363,6 @@ class Rules(ABC):
 
     def _sanitize_metric_name(self, metric_name: str) -> str:
         """Sanitize a metric name according to https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels."""
-        # TODO re.sub() instead of match. Check other examples in code base
         return "".join(char if re.match(r"[a-zA-Z0-9_:]", char) else "_" for char in metric_name)
 
     # ---- END STATIC HELPER METHODS --- #

--- a/tests/test_rules_promql.py
+++ b/tests/test_rules_promql.py
@@ -147,8 +147,8 @@ class TestAddRuleFromStr(unittest.TestCase):
             group_name="new",
             group_name_prefix="some",
         )
-        rules_dict = rules.as_dict()
         # THEN the new rule is a combination of all
+        rules_dict = rules.as_dict()
         # AND the added rule group name has the custom group name and prefix
         self.assertEqual({}, DeepDiff(expected_rules, rules_dict))
 
@@ -179,11 +179,15 @@ class TestFromStrGroupName(unittest.TestCase):
         # GIVEN an alert rule in single-rule format
         rules = AlertRules(query_type="promql")
         # WHEN processed as string and provided an illegal custom group name
-        groups = rules._from_str(self.single_rule, group_name="Foo$123/Hello:World(go_od)bye")
+        groups = rules._from_str(
+            self.single_rule, group_name="Foo$123/Hello:World(go_od)bye!@#^&*()[]{}|;:,.<>?`~_"
+        )
         for group in groups:
             # THEN the group name only contains characters in [a-zA-Z0-9_:]
-            # AND specials characters are replaced with "_"
-            self.assertEqual(group["name"], "Foo_123_Hello:World_go_od_bye_alerts")
+            # AND special characters are replaced with "_"
+            self.assertEqual(
+                group["name"], "Foo_123_Hello:World_go_od_bye______________:_________alerts"
+            )
 
     def test_single_rule_from_string(self):
         # GIVEN an alert rule in single-rule format

--- a/tests/test_rules_promql.py
+++ b/tests/test_rules_promql.py
@@ -41,6 +41,7 @@ class TestEndpointProvider(unittest.TestCase):
                     self.assertIn("juju_application", labels)
                     self.assertIn("juju_model_uuid", labels)
                     # alerts should not have unit information if not already present
+                    # https://discourse.charmhub.io/t/juju-topology-labels/8874
                     self.assertNotIn("juju_unit", rule["labels"])
                     self.assertNotIn("juju_unit=", rule["expr"])
                 else:
@@ -76,47 +77,188 @@ class TestEndpointProvider(unittest.TestCase):
                 self.assertIn("juju_model_uuid", labels)
                 self.assertIn("juju_application", labels)
 
-    def test_injecting_generic_alerts(self):
-        ri = AlertRules(
-            query_type="promql",
-            topology=JujuTopology(
-                model="unittest",
-                model_uuid=str(uuid.uuid4()),
-                unit="tester/0",
-                application="tester",
-            ),
+
+class TestAddRuleFromStr(unittest.TestCase):
+    def setUp(self):
+        rule = """
+            alert: SomeRuleName
+            expr: up
+            labels:
+              severity: critical
+        """
+        self.rule = yaml.safe_load(textwrap.dedent(rule))
+
+    def test_official_rule_add_alerts_from_string(self):
+        official_rule = """
+            groups:
+              - name: SomeGroupName
+                rules:
+                - alert: FooRule
+                  expr: up < 1
+                  labels:
+                    severity: critical
+                - alert: BarRule
+                  expr: absent(up)
+                  labels:
+                    severity: critical
+        """
+        added_group = yaml.safe_load(textwrap.dedent(official_rule))["groups"][0]
+        expected_rules = {
+            "groups": [
+                {
+                    "name": "initial_alerts",
+                    "rules": [self.rule],
+                },
+                {"name": "SomeGroupName_alerts", "rules": added_group["rules"]},
+            ]
+        }
+        # GIVEN an alert rule
+        rules = AlertRules(query_type="promql")
+        rules.groups = rules._from_str(self.rule, group_name="initial")
+        # WHEN a rule is added from string in official-rule format
+        rules.add(yaml.safe_load(textwrap.dedent(official_rule)))
+        rules_dict = rules.as_dict()
+        # THEN the new rule is a combination of all
+        self.assertEqual({}, DeepDiff(expected_rules, rules_dict))
+
+    def test_single_rule_add_alerts_from_string(self):
+        single_rule = """
+            alert: BarRule
+            expr: up < 1
+            labels:
+              severity: critical
+        """
+        rules = yaml.safe_load(textwrap.dedent(single_rule))
+        expected_rules = {
+            "groups": [
+                {
+                    "name": "initial_alerts",
+                    "rules": [self.rule],
+                },
+                {"name": "some_new_alerts", "rules": [rules]},
+            ]
+        }
+        # GIVEN an alert rule
+        rules = AlertRules(query_type="promql")
+        rules.groups = rules._from_str(self.rule, group_name="initial")
+        # WHEN a rule is added from string in single-rule format with a custom group name and prefix
+        rules.add(
+            yaml.safe_load(textwrap.dedent(single_rule)),
+            group_name="new",
+            group_name_prefix="some",
         )
-        ri.add_path(Path(__file__).resolve().parent / "promql_rules" / "prometheus_alert_rules")
+        rules_dict = rules.as_dict()
+        # THEN the new rule is a combination of all
+        # AND the added rule group name has the custom group name and prefix
+        self.assertEqual({}, DeepDiff(expected_rules, rules_dict))
 
-        # TODO SingleRuleFormat only require alert, expr, labels. Test others though
-        generic_alert_rules = """
-                groups:
-                - name: GenericRules
-                  rules:
-                  - alert: HostDown
-                    expr: up < 1
-                    for: 5m
-                    labels:
-                      severity: critical
-                  - alert: HostUnavailable
-                    expr: absent(up)
-                    for: 5m
-                    labels:
-                      severity: critical
-                """
 
-        ri.add(generic_alert_rules)
+class TestFromStrGroupName(unittest.TestCase):
+    def setUp(self):
+        official_rule = """
+            groups:
+              - name: SomeGroupName
+                rules:
+                - alert: SomeRuleName
+                  expr: up < 1
+                  for: 5m
+                  labels:
+                    severity: critical
+        """
+        single_rule = """
+            alert: SomeRuleName
+            expr: up < 1
+            for: 5m
+            labels:
+              severity: critical
+        """
+        self.official_rule = yaml.safe_load(textwrap.dedent(official_rule))
+        self.single_rule = yaml.safe_load(textwrap.dedent(single_rule))
 
-        alerts = ri.as_dict()
-        self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 5)
-        group = alerts["groups"][0]
-        for rule in group["rules"]:
-            self.assertIn("expr", rule)
-            for labels in expression_labels(rule["expr"]):
-                self.assertIn("juju_model", labels)
-                self.assertIn("juju_model_uuid", labels)
-                self.assertIn("juju_application", labels)
+    def test_single_rule_from_string_group_sanitized(self):
+        # GIVEN an alert rule in single-rule format
+        rules = AlertRules(query_type="promql")
+        # WHEN processed as string and provided an illegal custom group name
+        groups = rules._from_str(self.single_rule, group_name="Foo$123/Hello:World(go_od)bye")
+        for group in groups:
+            # THEN the group name only contains characters in [a-zA-Z0-9_:]
+            # AND specials characters are replaced with "_"
+            self.assertEqual(group["name"], "Foo_123_Hello:World_go_od_bye_alerts")
+
+    def test_single_rule_from_string(self):
+        # GIVEN an alert rule in single-rule format
+        rules = AlertRules(query_type="promql")
+        # WHEN processed as string
+        groups = rules._from_str(self.single_rule)
+        for group in groups:
+            # THEN group name contains hash
+            self.assertNotEqual(get_hash(group["name"]), "")
+
+    def test_single_rule_from_string_custom_group(self):
+        # GIVEN an alert rule in single-rule format
+        rules = AlertRules(query_type="promql")
+        # WHEN processed as string and provided custom group name
+        groups = rules._from_str(self.single_rule, group_name="foo")
+        for group in groups:
+            # THEN group name does not contain hash
+            self.assertEqual(get_hash(group["name"]), "")
+            # AND group name contains the custom group name
+            self.assertIn("foo", group["name"])
+
+    def test_single_rule_from_string_custom_group_prefix(self):
+        # GIVEN an alert rule in single-rule format
+        rules = AlertRules(query_type="promql")
+        # WHEN processed as string and provided custom group name prefix
+        groups = rules._from_str(self.single_rule, group_name_prefix="foo")
+        for group in groups:
+            # THEN group name does not include the original group name
+            self.assertNotIn("SomeGroupName", group["name"])
+            # AND group name is prefixed with custom value
+            self.assertTrue(group["name"].startswith("foo"))
+
+    def test_official_rule_from_string(self):
+        # GIVEN an alert rule in official-rule format
+        rules = AlertRules(query_type="promql")
+        # WHEN processed as string
+        groups = rules._from_str(self.official_rule)
+        for group in groups:
+            # THEN group name matches the group name in the alert
+            self.assertIn("SomeGroupName", group["name"])
+
+    def test_official_rule_from_string_custom_group_prefix(self):
+        # GIVEN an alert rule in official-rule format
+        rules = AlertRules(query_type="promql")
+        # WHEN processed as string and provided custom group name prefix
+        groups = rules._from_str(self.official_rule, group_name_prefix="foo")
+        for group in groups:
+            # THEN group name includes the original group name
+            self.assertIn("SomeGroupName", group["name"])
+            # AND group name is prefixed with custom value
+            self.assertTrue(group["name"].startswith("foo"))
+
+    def test_raises_value_error_empty_str(self):
+        rules = AlertRules(query_type="promql")
+        with self.assertRaises(ValueError) as ctx:
+            rules._from_str("")
+        self.assertEqual(str(ctx.exception), "Empty")
+
+    def test_raises_value_error_not_dict(self):
+        rules = AlertRules(query_type="promql")
+        with self.assertRaises(ValueError) as ctx:
+            rules._from_str("[]")
+        self.assertEqual(str(ctx.exception), "Invalid rules (must be a dict)")
+
+    def test_raises_value_error_invalid_rule_format(self):
+        invalid_rule = """
+            expr: up < 1
+            for: 5m
+            labels:
+              severity: critical
+        """
+        rules = AlertRules(query_type="promql")
+        with self.assertRaises(ValueError) as ctx:
+            rules._from_str(yaml.safe_load(textwrap.dedent(invalid_rule)))
+        self.assertEqual(str(ctx.exception), "Invalid rule format")
 
 
 def sorted_matchers(matchers) -> str:
@@ -140,6 +282,27 @@ def expression_labels(expr):
         match = match.replace("=", '":').replace("juju_", '"juju_')
         labels = json.loads(match)
         yield labels
+
+
+def get_hash(group_name: str) -> str:
+    """Extract the hash of the group name when a group name was not provided to _from_str method in the Rules class.
+
+    This occurs when the single-rule format is provided rather than official-rule format.
+
+    Args:
+        group_name: a string representing the group name of the rules.
+
+    Returns:
+        the matching hexdigest of the group name if a match is found, otherwise an empty string.
+    """
+    import re
+
+    pattern = r"([a-f0-9]{20})_"
+    match = re.search(pattern, group_name)
+    if match:
+        return match.group(1)
+    else:
+        return ""
 
 
 class TestAlertRulesWithOneRulePerFile(unittest.TestCase):

--- a/tests/test_rules_promql.py
+++ b/tests/test_rules_promql.py
@@ -242,12 +242,6 @@ class TestFromStrGroupName(unittest.TestCase):
             rules._from_str("")
         self.assertEqual(str(ctx.exception), "Empty")
 
-    def test_raises_value_error_not_dict(self):
-        rules = AlertRules(query_type="promql")
-        with self.assertRaises(ValueError) as ctx:
-            rules._from_str("[]")
-        self.assertEqual(str(ctx.exception), "Invalid rules (must be a dict)")
-
     def test_raises_value_error_invalid_rule_format(self):
         invalid_rule = """
             expr: up < 1


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Currently, anyone who wants to have up/absent alerts for their charm they would have to do this per charm.

“up” has slightly different semantics between remote-write and scrape:
- if prometheus failed to scrape, then it’s down.
- if grafana agent failed to to remote-write (regardles of whether scrape succeeded) then it’s absent.

To help with centralizing the up/absent rules, we need a convenient way to "inject" alerts on the fly.

## Solution
<!-- A summary of the solution addressing the above issue -->
Support for generic alerts can be centralised in cos-lib by adding the functionality to add rules from a string in either single-rule or official-rule format. This then allows Prometheus (and Mimir) or Grafana Agent to consume this functionality and have a generic up/absent rule in their library provided by the O11y team using best-practice knowledge. This prevents operators having to make their own up/abesnt rules and potentially not using best-practice alerting methods.

When adding rules from string a custom group name and/or prefix is acceptable which is sanitized according to [Prometheus metric name format](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels), replacing illegal characters for underscores.

### Example Implementation
Given a rule from string in official-rule format (can also be single-rule format)
```
generic_rules = yaml.safe_load(
    textwrap.dedent(
        """
        groups:
          - name: MyHostHealth
            rules:
            - alert: HostDown
              expr: up < 1
              labels:
                severity: critical
            - alert: HostUnavailable
              expr: absent(up)
              labels:
                severity: critical
        """
    )
)
```
Add the rules from string to the existing rule set
```
alert_rules = AlertRules(query_type="promql", topology=self.topology)
alert_rules.add(generic_rules)
```

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
This is an ops-independent change. See unit tests.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

