### PR TITLE
fix: don't run chmod on cos-tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.50"
+version = "0.0.51"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -187,12 +187,9 @@ class CosTool:
         arch = "amd64" if arch == "x86_64" else arch
         res = "cos-tool-{}".format(arch)
         try:
-            path = Path(res).resolve()
-            path.chmod(0o777)
+            path = Path(res).resolve(strict=True)
             return path
-        except NotImplementedError:
-            logger.debug("System lacks support for chmod")
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None
 

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,9 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib
 commands =
     python -m doctest {[vars]src_path}/cosl/mandatory_relation_pairs.py
-    /usr/bin/env sh -c 'stat cos-tool-amd64 > /dev/null 2>&1 || curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64'
+    /usr/bin/env sh -c 'stat cos-tool-amd64 > /dev/null 2>&1 || \
+        curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-amd64'
+    /usr/bin/env sh -c 'chmod 755 cos-tool-amd64'
     pytest {tty:--color=yes} --cov={[vars]src_path} --cov-config={tox_root}/pyproject.toml \
         ;    for us
         --cov-report=html:{tox_root}/results/html-cov/ \


### PR DESCRIPTION
## Issue
Addresses https://github.com/canonical/grafana-agent-operator/issues/208.


## Solution
Leave to chmod to charmcraft.yaml and drop it from the lib.


## Context
Currently, CosTool duplicates are still in use, and were patched separately:
- https://github.com/canonical/grafana-k8s-operator/pull/371/files#diff-69ab969563d8e0133c6a9e31a0a235f99a626617c456bc84bb1bd25899e36170
- https://github.com/canonical/prometheus-k8s-operator/pull/664/files#diff-3eb4f4fb71ab351956c8e7b96b07a804995e81540a0d2e94c2f63333c7792f79
- https://github.com/canonical/loki-k8s-operator/pull/485/files#diff-ad7051b5ca68befcdb77d638fcfa686fa902ae8089c8e72cea3c222df01a4597
