### PR TITLE
Centralized rules groups for libraries to import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.50"
+version = "0.0.51"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.51"
+version = "0.0.53"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -140,7 +140,7 @@ generic_alert_groups: Final = SimpleNamespace(
     },
     # If we push to Prometheus via remote-write with an aggregator, there are no
     # UP metrics associated. Only a time series for the metrics we have pushed is available
-    # so ommit the HostDown and keep the HostMetricsMissing rules.
+    # so omit the HostDown and keep the HostMetricsMissing rules.
     aggregator_rules={
         "groups": [
             {

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -80,6 +80,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, Final, List, Optional, Union, cast
 
 import yaml
@@ -93,57 +94,57 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
+
+generic_alert_rules: Final = SimpleNamespace(
+    host_down={
+        "alert": "HostDown",
+        "expr": "up < 1",
+        "for": "5m",
+        "labels": {"severity": "critical"},
+        "annotations": {
+            "summary": "Host '{{ $labels.instance }}' is down.",
+            "description": """Host '{{ $labels.instance }}' is down, failed to scrape.
+                            VALUE = {{ $value }}
+                            LABELS = {{ $labels }}""",
+        },
+    },
+    host_metrics_missing={
+        "alert": "HostMetricsMissing",
+        "expr": "absent(up)",
+        "for": "5m",
+        "labels": {"severity": "critical"},
+        "annotations": {
+            "summary": "Metrics not received from host '{{ $labels.instance }}', failed to remote write.",
+            "description": """Metrics not received from host '{{ $labels.instance }}', failed to remote write.
+                            VALUE = {{ $value }}
+                            LABELS = {{ $labels }}""",
+        },
+    },
+)
+
 """
 Generic alert rules are in groups to ensure a predictable group name. The group names must be unique in a Prometheus installation.
 Charmed Prometheus-k8s handles this with injecting JujuTopology information into the group name.
-
 """
-
-_HOST_DOWN = {
-    "alert": "HostDown",
-    "expr": "up < 1",
-    "for": "5m",
-    "labels": {"severity": "critical"},
-    "annotations": {
-        "summary": "Host '{{ $labels.instance }}' is down.",
-        "description": """Host '{{ $labels.instance }}' is down, failed to scrape.
-                            VALUE = {{ $value }}
-                            LABELS = {{ $labels }}""",
+generic_alert_groups: Final = SimpleNamespace(
+    application_rules={
+        "groups": [
+            {
+                "name": "HostHealth",
+                "rules": [generic_alert_rules.host_down, generic_alert_rules.host_metrics_missing],
+            },
+        ]
     },
-}
-
-_HOST_METRICS_MISSING = {
-    "alert": "HostMetricsMissing",
-    "expr": "absent(up)",
-    "for": "5m",
-    "labels": {"severity": "critical"},
-    "annotations": {
-        "summary": "Metrics not received from host '{{ $labels.instance }}', failed to remote write.",
-        "description": """Metrics not received from host '{{ $labels.instance }}', failed to remote write.
-                            VALUE = {{ $value }}
-                            LABELS = {{ $labels }}""",
+    # TODO Mention why Aggregator only has absent
+    aggregator_rules={
+        "groups": [
+            {
+                "name": "AggregatorHostHealth",
+                "rules": [generic_alert_rules.host_metrics_missing],
+            },
+        ]
     },
-}
-
-# TODO Consider namespacing class GenericAlertRules.application
-GENERIC_APPLICATION_RULES_GROUP: Final = {
-    "groups": [
-        {
-            "name": "HostHealth",
-            "rules": [_HOST_DOWN, _HOST_METRICS_MISSING],
-        },
-    ]
-}
-
-# TODO Mention why Aggregator only has absent
-GENERIC_AGGREGATOR_RULES_GROUP: Final = {
-    "groups": [
-        {
-            "name": "AggregatorHostHealth",
-            "rules": [_HOST_METRICS_MISSING],
-        },
-    ]
-}
+)
 
 
 class InvalidRulePathError(Exception):

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -95,7 +95,7 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
-generic_alert_rules: Final = SimpleNamespace(
+_generic_alert_rules: Final = SimpleNamespace(
     host_down={
         "alert": "HostDown",
         "expr": "up < 1",
@@ -131,7 +131,7 @@ generic_alert_groups: Final = SimpleNamespace(
         "groups": [
             {
                 "name": "HostHealth",
-                "rules": [generic_alert_rules.host_down, generic_alert_rules.host_metrics_missing],
+                "rules": [_generic_alert_rules.host_down, _generic_alert_rules.host_metrics_missing],
             },
         ]
     },
@@ -140,7 +140,7 @@ generic_alert_groups: Final = SimpleNamespace(
         "groups": [
             {
                 "name": "AggregatorHostHealth",
-                "rules": [generic_alert_rules.host_metrics_missing],
+                "rules": [_generic_alert_rules.host_metrics_missing],
             },
         ]
     },

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -131,11 +131,16 @@ generic_alert_groups: Final = SimpleNamespace(
         "groups": [
             {
                 "name": "HostHealth",
-                "rules": [_generic_alert_rules.host_down, _generic_alert_rules.host_metrics_missing],
+                "rules": [
+                    _generic_alert_rules.host_down,
+                    _generic_alert_rules.host_metrics_missing,
+                ],
             },
         ]
     },
-    # TODO Mention why Aggregator only has absent
+    # If we push to Prometheus via remote-write with an aggregator, there are no
+    # UP metrics associated. Only a time series for the metrics we have pushed is available
+    # so ommit the HostDown and keep the HostMetricsMissing rules.
     aggregator_rules={
         "groups": [
             {

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -112,7 +112,8 @@ _generic_alert_rules: Final = SimpleNamespace(
     },
     host_metrics_missing={
         "alert": "HostMetricsMissing",
-        # We use "for: 5m" instead of "absent_over_time" because ... (I forget)
+        # We use "absent(up)" with "for: 5m" because the alert transitions from "Pending" to "Firing".
+        # If query portability is desired, "absent_over_time(up[5m])" is an alternative.
         "expr": "absent(up)",
         "for": "5m",
         "labels": {"severity": "critical"},
@@ -148,7 +149,9 @@ generic_alert_groups: Final = SimpleNamespace(
         "groups": [
             {
                 "name": "AggregatorHostHealth",
-                "rules": [_generic_alert_rules.host_metrics_missing],
+                "rules": [
+                    _generic_alert_rules.host_metrics_missing,
+                ],
             },
         ]
     },


### PR DESCRIPTION
This PR attempts to centralize the generic alert rule groups in cos-lib to remove code duplication. It is an extension of this merged PR:
- https://github.com/canonical/cos-lib/pull/115

Tandem PRs:
- https://github.com/canonical/prometheus-k8s-operator/pull/660
- https://github.com/canonical/grafana-agent-operator/pull/232
- https://github.com/canonical/avalanche-k8s-operator/pull/50

Note:
- This will not break any CI since the generic rules existed in the Prometheus and Grafana agent libraries. Those will still exist there until the migration to these rules in `cosl` is complete.
- This PR is not dependent on the status of the tandem PRs, rather they are dependent on this one! 