### PR TITLE
fix stack overflow error on failed loki_logger emit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.51"
+version = "0.0.52"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/loki_logger.py
+++ b/src/cosl/loki_logger.py
@@ -80,8 +80,9 @@ class LokiEmitter:
             resp = self._send_request(req, jsondata_encoded)
         except urllib.error.HTTPError as e:
             if not self._error_notified_once:
-                logger.error(f"error pushing logs to {self.url}: {e.status, e.reason}")  # type: ignore
+                # set this BEFORE logging anything, or we'll recurse into a stack overflow!
                 self._error_notified_once = True
+                logger.error(f"error pushing logs to {self.url}: {e.code, e.reason}")  # type: ignore
             return
 
         if resp.getcode() != self.success_response_code:


### PR DESCRIPTION
We had an internally reported issue where an error in pushing logs into loki would trigger a stack overflow, because the exception handling code was in turn logging an error message triggering error recursion.

Added a test to verify.
