### PR TITLE
pin ops dependency to < 2.18

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ deps =
     fs
     pytest
     pytest-cov
+    ; https://github.com/canonical/operator/issues/1555
     ops[testing] < 2.18
     cryptography
     jsonschema

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
     fs
     pytest
     pytest-cov
-    ops[testing]
+    ops[testing] < 2.18
     cryptography
     jsonschema
     PyYAML


### PR DESCRIPTION
## Issue
Failing unit test in operator framework dependency

on test: `tests/test_coordinated_workers/test_coordinator.py`
