### PR TITLE
fix: remove ops pin in unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
     pytest
     pytest-cov
     ; https://github.com/canonical/operator/issues/1555
-    ops[testing] < 2.18
+    ops[testing]
     cryptography
     jsonschema
     PyYAML


### PR DESCRIPTION
[#1555](https://github.com/canonical/operator/issues/1555) is resolved, and the ops pin can be removed in unit tests

## Testing Instructions
unit tests pass
