### PR TITLE
Add a utility function to check for ipv6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.54"
+version = "0.0.55"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -4,6 +4,7 @@
 """Workload manager for Nginx. Used by the coordinator to load-balance and group the workers."""
 
 import logging
+import subprocess
 from pathlib import Path
 from typing import Callable, Optional, TypedDict
 
@@ -205,3 +206,15 @@ class NginxPrometheusExporter:
                 },
             }
         )
+
+
+def is_ipv6_enabled() -> bool:
+    """Check if IPv6 is enabled on the container's network interfaces."""
+    exit_code, output = subprocess.getstatusoutput("ip -6 address show")
+    if exit_code != 0:
+        # if running the command failed for any reason, assume ipv6 is not enabled.
+        logger.warning(f"Disabling ipv6 in nginx config: {output}")
+        return False
+    if output:
+        return True
+    return False

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -210,11 +210,11 @@ class NginxPrometheusExporter:
 
 def is_ipv6_enabled() -> bool:
     """Check if IPv6 is enabled on the container's network interfaces."""
-    exit_code, output = subprocess.getstatusoutput("ip -6 address show")
-    if exit_code != 0:
+    try:
+        output = subprocess.run(
+            ["ip", "-6", "address", "show"], check=True, capture_output=True, text=True
+        )
+    except subprocess.CalledProcessError:
         # if running the command failed for any reason, assume ipv6 is not enabled.
-        logger.warning(f"Disabling ipv6 in nginx config: {output}")
         return False
-    if output:
-        return True
-    return False
+    return bool(output.stdout)


### PR DESCRIPTION
## Issue
Our HA solutions running nginx insert a default config for listening on ipv6 addresses. In an environment where ipv6 is disabled, nginx fails to start.

## Solution
Add a common utility function that can be used by the nginx config to add/remove ipv6-related options.


## Testing Instructions
Tandem PR: TODO


