### PR TITLE
Publish worker workload versions and the worker config corresponding version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.55"
+version = "0.0.56"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -611,6 +611,14 @@ class Coordinator(ops.Object):
             # if is_recommended is None: it means we don't have a recommended deployment criterion.
             statuses.append(ops.ActiveStatus("Degraded."))
 
+        worker_versions = self.cluster.gather_workload_versions()
+        if len(worker_versions) > 1:
+            statuses.append(
+                ops.BlockedStatus(
+                    f"[consistency] Workers are running different versions: {', '.join(worker_versions)}"
+                )
+            )
+
         if not self.s3_requirer.relations:
             statuses.append(ops.BlockedStatus("[s3] Missing S3 integration."))
         elif not self.s3_ready:

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -405,7 +405,7 @@ class Coordinator(ops.Object):
             options=nginx_options,
         )
 
-        self._workers_config = ConfigBuilderFactory(
+        self._config_builder_factory = ConfigBuilderFactory(
             self,
             workers_config,
             config_builders,
@@ -758,7 +758,7 @@ class Coordinator(ops.Object):
                         f"[consistency] Workers are running different versions: {', '.join(sorted(worker_versions))}"
                     )
                 )
-            if self._config_builders and not self._workers_config.get_version():
+            if self._config_builders and not self._config_builder_factory.get_version():
                 statuses.append(
                     ops.BlockedStatus(
                         f"Workers are requesting a config for a version: {worker_versions.pop()} that is not supported."
@@ -854,8 +854,8 @@ class Coordinator(ops.Object):
         # On every function call, we always publish everything to the databag; however, if there
         # are no changes, Juju will notice there's no delta and do nothing
         self.cluster.publish_data(
-            worker_config=self._workers_config.build_config(),
-            worker_config_version=self._workers_config.get_version(),
+            worker_config=self._config_builder_factory.build_config(),
+            worker_config_version=self._config_builder_factory.get_version(),
             loki_endpoints=self.loki_endpoints_by_unit,
             # all arguments below are optional:
             ca_cert=self.cert_handler.ca_cert,

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -507,10 +507,11 @@ class Coordinator(ops.Object):
             )
             return
 
-        if len(self.cluster.gather_workload_versions()) > 1:
+        workload_versions = self.cluster.gather_workload_versions()
+        if len(workload_versions) > 1:
             logger.error(
                 f"Incoherent deployment. {charm.unit.name} is connected to workers that are running "
-                f"different workload versions: {', '.join(self.cluster.gather_workload_versions())}. "
+                f"different workload versions: {', '.join(workload_versions)}. "
                 "This charm will be unresponsive and refuse to handle any event until "
                 "the situation is resolved by the cloud admin, to avoid data loss."
             )

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -237,7 +237,7 @@ class Coordinator(ops.Object):
             workload_tracing_protocols: A list of protocols that the worker intends to send
                 workload traces with.
             catalogue_item: A catalogue application entry to be sent to catalogue.
-            worker_config_version: A function generating the worker's workload version that corresponds to the generated worker config.
+            worker_config_version: A function returning the workload version for which the generated worker config is intended.
 
         Raises:
         ValueError:
@@ -376,6 +376,14 @@ class Coordinator(ops.Object):
                 "the situation is resolved by the cloud admin, to avoid data loss."
             )
             return
+
+        if len(self.cluster.gather_workload_versions()) > 1:
+            logger.error(
+                f"Incoherent deployment. {charm.unit.name} is connected to workers that are running "
+                f"different workload versions: {', '.join(self.cluster.gather_workload_versions())}. "
+                "This charm will be unresponsive and refuse to handle any event until "
+                "the situation is resolved by the cloud admin, to avoid data loss."
+            )
 
         self._reconcile()
 

--- a/src/cosl/coordinated_workers/worker.py
+++ b/src/cosl/coordinated_workers/worker.py
@@ -556,7 +556,7 @@ class Worker(ops.Object):
         if self._charm.unit.is_leader() and self.roles:
             logger.info(f"publishing roles: {self.roles}")
             try:
-                self.cluster.publish_app_roles(self.roles)
+                self.cluster.publish_app_data(self.roles, self.running_version())
             except ModelError as e:
                 # if we are handling an event prior to 'install', we could be denied write access
                 # Swallowing the exception here relies on the reconciler pattern - this will be

--- a/src/cosl/interfaces/cluster.py
+++ b/src/cosl/interfaces/cluster.py
@@ -346,6 +346,24 @@ class ClusterProvider(Object):
             return address_set.pop()
         return None
 
+    def gather_workload_versions(self) -> Set[str]:
+        """Gather workerss published workload versions."""
+        data: Set[str] = set()
+        for relation in self._relations:
+            if relation.app:
+                remote_app_databag = relation.data[relation.app]
+                try:
+                    workload_version = ClusterRequirerAppData.load(
+                        remote_app_databag
+                    ).workload_version
+                except cosl.interfaces.utils.DataValidationError as e:
+                    log.error(f"invalid databag contents: {e}")
+                    continue
+
+                if workload_version:
+                    data.add(workload_version)
+        return data
+
     def _remote_data_ready(self, relation: ops.Relation) -> bool:
         """Verify that each worker unit and the worker leader have published their data to the cluster relation.
 

--- a/src/cosl/interfaces/cluster.py
+++ b/src/cosl/interfaces/cluster.py
@@ -98,7 +98,7 @@ class ClusterRequirerAppData(cosl.interfaces.utils.DatabagModel):
 
     role: str
     workload_version: Optional[str] = None
-    """The version of the worker's workload."""
+    """The worker's workload version."""
 
 
 class ClusterRequirerUnitData(cosl.interfaces.utils.DatabagModel):
@@ -115,7 +115,7 @@ class ClusterProviderAppData(cosl.interfaces.utils.DatabagModel):
     worker_config: str
     """The whole worker workload configuration, whatever it is. E.g. yaml-encoded things."""
     worker_config_version: Optional[str] = None
-    """The version of the worker's workload that corresponds to the generated `worker_config`."""
+    """The workload version for which the generated `worker_config` is intended."""
 
     ### self-monitoring stuff
     loki_endpoints: Optional[Dict[str, str]] = None
@@ -347,7 +347,7 @@ class ClusterProvider(Object):
         return None
 
     def gather_workload_versions(self) -> Set[str]:
-        """Gather workerss published workload versions."""
+        """Gather workers' published workload versions."""
         data: Set[str] = set()
         for relation in self._relations:
             if relation.app:

--- a/tests/test_coordinated_workers/conftest.py
+++ b/tests/test_coordinated_workers/conftest.py
@@ -45,5 +45,8 @@ def patch_all(tmp_path: Path):
                 new=Path(tmp_path / "rootcacert"),
             )
         )
+        stack.enter_context(
+            patch("cosl.coordinated_workers.worker.Worker.running_version", lambda _: "2.0")
+        )
 
         yield


### PR DESCRIPTION
## Issue
Tempo 2.7.1 comes with a breaking change in configuration: configs for <2.7.1 will not work with tempo >=2.7.1 and vice versa.
When doing in-track upgrades, we must find a way to prevent the user from refreshing the worker charms to a revision deploying tempo >=2.7.1, while the coordinator still publishes a <2.7.1 config version or vice versa.


## Solution
- Workers publish their own workload versions to `cluster` app data
- The coordinator would be set to BlockedState if its connected to workers with different workload versions and not give them a config.
- In addition to the config, the coordinator will send `worker_config_version` that corresponds to the workload version that this config is generated for, so that the worker can verify that the coordinator revision is modern enough to be aware of this versioned configuration requirement.

## Testing Instructions
Tandem PRs:
- https://github.com/canonical/tempo-coordinator-k8s-operator/pull/115
- https://github.com/canonical/tempo-worker-k8s-operator/pull/58
