### PR TITLE
Fix tool path for arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.57"
+version = "0.0.58"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -184,7 +184,10 @@ class CosTool:
 
     def _get_tool_path(self) -> Optional[Path]:
         arch = platform.machine()
-        arch = "amd64" if arch == "x86_64" else arch
+        if arch == "x86_64":
+            arch = "amd64"
+        elif arch == "aarch64":
+            arch = "arm64"
         res = "cos-tool-{}".format(arch)
         try:
             path = Path(res).resolve(strict=True)

--- a/src/cosl/loki_logger.py
+++ b/src/cosl/loki_logger.py
@@ -126,9 +126,7 @@ class LokiEmitter:
         if not isinstance(extra_labels, dict):
             return labels
 
-        label_name: Any
-        label_value: Any
-        for label_name, label_value in extra_labels.items():
+        for label_name, label_value in extra_labels.items():  # type: ignore
             if not isinstance(label_name, str) or not isinstance(label_value, str):
                 return labels
 

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 description = Run unit tests
 deps =
     .
-    deepdiff==8.4.1
+    deepdiff~=8.3
     fs
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 description = Run unit tests
 deps =
     .
-    deepdiff
+    deepdiff==8.4.1
     fs
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 description = Run unit tests
 deps =
     .
-    deepdiff~=8.3
+    deepdiff
     fs
     pytest
     pytest-cov


### PR DESCRIPTION
## Issue
On arm, grafana-agent produces the following logs:

```
Could not locate cos-tool at: "cos-tool-aarch64"
Skipping injection of juju topology as label matchers
`cos-tool` unavailable. Leaving expression unchanged: ...
```

while the filename we have on disk is cos-tool-arm64.


## Solution
Map aarch64 to arm64.

Related: https://github.com/canonical/cos-lib/issues/29


## Context
This is only a partial fix, because the CosTool class is still replicated in:
- [prometheus_scrape](https://github.com/canonical/grafana-agent-operator/blob/9589805fac6979edfa6853dc5853e339d966c27b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py#L2401)
- [remote_write](https://github.com/canonical/grafana-agent-operator/blob/9589805fac6979edfa6853dc5853e339d966c27b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py#L963)
- [grafana_dashboard](https://github.com/canonical/grafana-agent-operator/blob/9589805fac6979edfa6853dc5853e339d966c27b/lib/charms/grafana_k8s/v0/grafana_dashboard.py#L2098)
- [loki_push_api](https://github.com/canonical/grafana-agent-operator/blob/9589805fac6979edfa6853dc5853e339d966c27b/lib/charms/loki_k8s/v1/loki_push_api.py#L2797)

Related:
- https://github.com/canonical/grafana-agent-operator/blob/c240db4308374f4e64d146813cae8502b170c2f5/src/snap_management.py#L90

## Testing Instructions
Deploy the following bundle, and when it settles, inspect `juju debug-log --replay | grep "Could not locate cos-tool"`

```yaml
default-base: ubuntu@24.04/stable
applications:
  ga20:
    charm: grafana-agent
    channel: latest/edge
    revision: 453
    base: ubuntu@20.04/stable
  ga22:
    charm: grafana-agent
    channel: latest/edge
    revision: 452
    base: ubuntu@22.04/stable
  ga24:
    charm: grafana-agent
    channel: latest/edge
    revision: 454
  hwo20:
    charm: hardware-observer
    channel: latest/stable
    revision: 219
    base: ubuntu@20.04/stable
    resources:
      perccli-deb: 1
      sas2ircu-bin: 1
      sas3ircu-bin: 1
      storcli-deb: 1
  hwo22:
    charm: hardware-observer
    channel: latest/stable
    revision: 221
    base: ubuntu@22.04/stable
    resources:
      perccli-deb: 1
      sas2ircu-bin: 1
      sas3ircu-bin: 1
      storcli-deb: 1
  hwo24:
    charm: hardware-observer
    channel: latest/stable
    revision: 217
    resources:
      perccli-deb: 1
      sas2ircu-bin: 1
      sas3ircu-bin: 1
      storcli-deb: 1
  ssc:
    charm: self-signed-certificates
    channel: latest/stable
    revision: 265
    base: ubuntu@22.04/stable
    num_units: 1
    to:
    - "3"
    constraints: arch=arm64
  ub20:
    charm: ubuntu
    channel: latest/stable
    revision: 25
    base: ubuntu@20.04/stable
    num_units: 1
    to:
    - "0"
    constraints: arch=arm64
    storage:
      block: loop,100M
      files: rootfs,100M
  ub22:
    charm: ubuntu
    channel: latest/stable
    revision: 25
    base: ubuntu@22.04/stable
    num_units: 1
    to:
    - "1"
    constraints: arch=arm64
    storage:
      block: loop,100M
      files: rootfs,100M
  ub24:
    charm: ubuntu
    channel: latest/stable
    revision: 25
    num_units: 1
    to:
    - "2"
    constraints: arch=arm64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "0":
    constraints: arch=arm64
    base: ubuntu@20.04/stable
  "1":
    constraints: arch=arm64
    base: ubuntu@22.04/stable
  "2":
    constraints: arch=arm64
  "3":
    constraints: arch=arm64
    base: ubuntu@22.04/stable
relations:
- - ga20:juju-info
  - ub20:juju-info
- - ga22:juju-info
  - ub22:juju-info
- - ga24:juju-info
  - ub24:juju-info
- - hwo20:general-info
  - ub20:juju-info
- - hwo20:cos-agent
  - ga20:cos-agent
- - hwo22:general-info
  - ub22:juju-info
- - hwo22:cos-agent
  - ga22:cos-agent
- - hwo24:general-info
  - ub24:juju-info
- - hwo24:cos-agent
  - ga24:cos-agent
- - ssc:certificates
  - ga20:certificates
- - ssc:certificates
  - ga22:certificates
- - ssc:certificates
  - ga24:certificates
```