### PR TITLE
Lift coordinators' nginx config generation to cosl 

### DIFF
--- a/.github/workflows/distributed-solutions-tests.yaml
+++ b/.github/workflows/distributed-solutions-tests.yaml
@@ -42,14 +42,11 @@ jobs:
           sed -i -e "/^cosl[ ><=]/d" -e "/canonical\/cos-lib/d" -e "/#egg=cosl/d" requirements.txt
           echo -e "\ngit+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@${{ github.head_ref || github.ref_name }}#egg=cosl" >> requirements.txt
 
-      - name: Add charmcraft build dependencies (git)
-        run: yq e '.parts.charm.build-packages += ["git"]' -i charmcraft.yaml
-
       - name: Run the charm's unit tests
         id: unit
         run: |
           if [ -f tox.ini ]; then  # Run Tox
-            tox -e unit,scenario
+            tox -e unit
           elif [ -f Makefile ]; then # Run Make
             make unit
           else
@@ -61,7 +58,7 @@ jobs:
         id: static
         run: |
           if [ -f tox.ini ]; then  # Run Tox
-            tox -e static-charm,static-lib
+            tox -e static
           elif [ -f Makefile ]; then # Run Make
             make static
           else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.0.57"
+version = "0.1.0"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]
@@ -104,4 +104,3 @@ ignore-words-list = "assertIn"
 [tool.hatch.metadata]
 # allow git+ dependencies in pyproject
 allow-direct-references = true
-

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -35,6 +35,7 @@ import cosl
 from cosl.coordinated_workers import worker
 from cosl.coordinated_workers.nginx import (
     Nginx,
+    NginxConfig,
     NginxMappingOverrides,
     NginxPrometheusExporter,
 )
@@ -198,7 +199,7 @@ class Coordinator(ops.Object):
         external_url: str,  # the ingressed url if we have ingress, else fqdn
         worker_metrics_port: int,
         endpoints: _EndpointMapping,
-        nginx_config: Callable[["Coordinator"], str],
+        nginx_config: NginxConfig,
         workers_config: Callable[["Coordinator"], str],
         worker_ports: Optional[Callable[[str], Sequence[int]]] = None,
         nginx_options: Optional[NginxMappingOverrides] = None,
@@ -274,7 +275,9 @@ class Coordinator(ops.Object):
 
         self.nginx = Nginx(
             self._charm,
-            partial(nginx_config, self),
+            config_getter=partial(
+                nginx_config.get_config, self.cluster.gather_addresses_by_role()
+            ),
             options=nginx_options,
         )
         self._workers_config_getter = partial(workers_config, self)
@@ -780,5 +783,7 @@ class Coordinator(ops.Object):
             "memory": self._charm.model.config.get(memory_limit_key),
         }
         return adjust_resource_requirements(
-            limits, self._resources_requests_getter(), adhere_to_requests=True  # type: ignore
+            limits,
+            self._resources_requests_getter(),
+            adhere_to_requests=True,  # type: ignore
         )

--- a/src/cosl/coordinated_workers/coordinator.py
+++ b/src/cosl/coordinated_workers/coordinator.py
@@ -783,7 +783,5 @@ class Coordinator(ops.Object):
             "memory": self._charm.model.config.get(memory_limit_key),
         }
         return adjust_resource_requirements(
-            limits,
-            self._resources_requests_getter(),
-            adhere_to_requests=True,  # type: ignore
+            limits, self._resources_requests_getter(), adhere_to_requests=True  # type: ignore
         )

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -89,14 +89,13 @@ class NginxConfig:
     def _prepare_config(
         self, addresses_by_role: Dict[str, Set[str]], tls: bool
     ) -> List[Dict[str, Any]]:
-        log_level = "error"
         upstreams = self._upstreams(addresses_by_role)
         # extract the upstream name
         upstream_names = [upstream["args"][0] for upstream in upstreams]
         # build the complete configuration
         full_config = [
             {"directive": "worker_processes", "args": ["5"]},
-            {"directive": "error_log", "args": ["/dev/stderr", log_level]},
+            {"directive": "error_log", "args": ["/dev/stderr", "error"]},
             {"directive": "pid", "args": ["/tmp/nginx.pid"]},
             {"directive": "worker_rlimit_nofile", "args": ["8192"]},
             {

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -283,7 +283,11 @@ class NginxConfig:
                 nginx_locations.append(
                     {
                         "directive": "location",
-                        "args": [location.modifier.value, location.path],
+                        "args": (
+                            [location.path]
+                            if location.modifier == NginxLocationModifier.DEFAULT
+                            else [location.modifier.value, location.path]
+                        ),
                         "block": [
                             {
                                 "directive": "set",

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -232,7 +232,7 @@ class NginxConfig:
         is_grpc = any(loc.is_grpc for loc in locations)
         locations = self._locations(locations, is_grpc, upstream_names, tls)
         server_config = {}
-        if len(locations) == 0:
+        if len(locations) > 0:
             server_config = {
                 "directive": "server",
                 "args": [],
@@ -283,7 +283,7 @@ class NginxConfig:
                 nginx_locations.append(
                     {
                         "directive": "location",
-                        "args": [location.modifier, location.path],
+                        "args": [location.modifier.value, location.path],
                         "block": [
                             {
                                 "directive": "set",

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -48,7 +48,17 @@ class NginxLocationModifier(Enum):
 
 @dataclass
 class NginxLocationConfig:
-    """Represents a `location` block in an Nginx configuration."""
+    """Represents a `location` block in an Nginx configuration.
+
+    For example, NginxLocationConfig('/', 'foo', backend_url="/api/v1" headers={'a': 'b'}, modifier=EXACT, is_grpc=True)
+    would result in:
+        location = / {
+            set $backend grpc://foo/api/v1;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+            proxy_set_header a b;
+        }
+    """
 
     path: str
     backend: str

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -34,7 +34,7 @@ DEFAULT_OPTIONS: _NginxMapping = {
 RESOLV_CONF_PATH = "/etc/resolv.conf"
 
 
-class NginxLocationModifier(Enum):
+class NginxLocationModifier(str, Enum):
     """Enum representing valid Nginx `location` block modifiers."""
 
     # cfr. https://www.digitalocean.com/community/tutorials/nginx-location-directive#nginx-location-directive-syntax

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -8,7 +8,7 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, TypedDict
+from typing import Any, Callable, Dict, List, Optional, Set, TypedDict, cast
 
 from ops import CharmBase, pebble
 
@@ -63,7 +63,7 @@ class NginxLocationConfig:
     path: str
     backend: str
     backend_url: str = ""
-    headers: Dict[str, str] = field(default_factory=dict)
+    headers: Dict[str, str] = field(default_factory=lambda: cast(Dict[str, str], {}))
     modifier: NginxLocationModifier = NginxLocationModifier.PREFIX
     is_grpc: bool = False
 

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -36,11 +36,14 @@ RESOLV_CONF_PATH = "/etc/resolv.conf"
 
 class NginxLocationModifier(Enum):
     """Enum representing valid Nginx `location` block modifiers."""
-# cfr. https://www.digitalocean.com/community/tutorials/nginx-location-directive#nginx-location-directive-syntax
 
-    DEFAULT = ""  # prefix match
+    # cfr. https://www.digitalocean.com/community/tutorials/nginx-location-directive#nginx-location-directive-syntax
+
+    PREFIX = ""  # prefix match
     EXACT = "="  # exact match
-    REGEX = "~"  # case-sensitive regex
+    REGEX_CASE_SENSITIVE = "~"  # case-sensitive regex match
+    REGEX_CASE_INSENSITIVE = "~*"  # case-insensitive regex match
+    PREFIX_NO_REGEX = "^~"  # prefix match that disables further regex matching
 
 
 @dataclass
@@ -48,13 +51,13 @@ class NginxLocationConfig:
     """Represents a `location` block in an Nginx configuration."""
 
     upstream: str
-    path: str = "/"
-    modifier: NginxLocationModifier = NginxLocationModifier.DEFAULT
+    path: str
+    modifier: NginxLocationModifier = NginxLocationModifier.PREFIX
     is_grpc: bool = False
 
 
 class NginxConfig:
-    """Builds the Nginx configuration."""
+    """Responsible for building the Nginx configuration used by the coordinators."""
 
     def __init__(
         self,
@@ -286,7 +289,7 @@ class NginxConfig:
                         "directive": "location",
                         "args": (
                             [location.path]
-                            if location.modifier == NginxLocationModifier.DEFAULT
+                            if location.modifier == NginxLocationModifier.PREFIX
                             else [location.modifier.value, location.path]
                         ),
                         "block": [

--- a/src/cosl/coordinated_workers/nginx.py
+++ b/src/cosl/coordinated_workers/nginx.py
@@ -36,6 +36,7 @@ RESOLV_CONF_PATH = "/etc/resolv.conf"
 
 class NginxLocationModifier(Enum):
     """Enum representing valid Nginx `location` block modifiers."""
+# cfr. https://www.digitalocean.com/community/tutorials/nginx-location-directive#nginx-location-directive-syntax
 
     DEFAULT = ""  # prefix match
     EXACT = "="  # exact match
@@ -62,14 +63,14 @@ class NginxConfig:
         server_ports_to_locations: Dict[int, List[NginxLocationConfig]],
     ):
         try:
-            # TODO: lazy load crossplane to avoid adding an additional dependency to cosl
+            # we lazy-load crossplane to avoid adding a dependency to cosl as a whole
             import crossplane
 
             self._builder = crossplane.build
         except ModuleNotFoundError:
             raise RuntimeError(
-                "Unmet dependencies: the coordinator charm base is missing some dependencies. \
-            Please install them with: pip install crossplane"
+                "Unmet dependency: the coordinated-workers NginxConfig object depends on the 'crossplane' package. \
+            Please install it with: `pip install crossplane` and add it to your charm's dependencies."
             )
         self._server_name = server_name
         self._dns_IP_address = self._get_dns_ip_address()
@@ -78,7 +79,7 @@ class NginxConfig:
         self._server_ports_to_locations = server_ports_to_locations
 
     def get_config(self, addresses_by_role: Dict[str, Set[str]], tls: bool) -> str:
-        """Returns the rendered Nginx configuration as a string."""
+        """Render the Nginx configuration as a string."""
         full_config = self._prepare_config(addresses_by_role, tls)
         return self._builder(full_config)
 

--- a/src/cosl/loki_logger.py
+++ b/src/cosl/loki_logger.py
@@ -128,7 +128,7 @@ class LokiEmitter:
 
         label_name: Any
         label_value: Any
-        for label_name, label_value in extra_labels.items():
+        for label_name, label_value in extra_labels.items():  # type: ignore
             if not isinstance(label_name, str) or not isinstance(label_value, str):
                 return labels
 

--- a/tests/test_coordinated_workers/resources/sample_loki_nginx_conf.txt
+++ b/tests/test_coordinated_workers/resources/sample_loki_nginx_conf.txt
@@ -1,0 +1,104 @@
+worker_processes 5;
+error_log /dev/stderr error;
+pid /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+events {
+    worker_connections 4096;
+}
+http {
+    upstream read {
+        server worker-address:3100;
+    }
+    upstream write {
+        server worker-address:3100;
+    }
+    upstream all {
+        server worker-address:3100;
+    }
+    upstream backend {
+        server worker-address:3100;
+    }
+    upstream worker {
+        server worker-address:3100;
+    }
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+    map $status $loggable {
+        ~^[23] 0;
+        default 1;
+    }
+    access_log /dev/stderr;
+    sendfile on;
+    tcp_nopush on;
+    resolver 198.18.0.0;
+    map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        '' anonymous;
+    }
+    proxy_read_timeout 300;
+    server {
+        listen 8080;
+        listen [::]:8080;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location = / {
+            return 200 "'OK'";
+            auth_basic off;
+        }
+        location = /status {
+            stub_status;
+        }
+        location = /loki/api/v1/push {
+            set $backend http://write;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /loki/api/v1/rules {
+            set $backend http://backend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /prometheus {
+            set $backend http://backend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /api/v1/rules {
+            set $backend http://backend/loki/api/v1/rules;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /loki/api/v1/tail {
+            set $backend http://read;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location ~ /loki/api/.* {
+            set $backend http://read;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection upgrade;
+        }
+        location = /loki/api/v1/format_query {
+            set $backend http://worker;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /loki/api/v1/status/buildinfo {
+            set $backend http://worker;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /ring {
+            set $backend http://worker;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+}

--- a/tests/test_coordinated_workers/resources/sample_loki_nginx_conf_tls.txt
+++ b/tests/test_coordinated_workers/resources/sample_loki_nginx_conf_tls.txt
@@ -1,0 +1,108 @@
+worker_processes 5;
+error_log /dev/stderr error;
+pid /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+events {
+    worker_connections 4096;
+}
+http {
+    upstream read {
+        server worker-address:3100;
+    }
+    upstream write {
+        server worker-address:3100;
+    }
+    upstream all {
+        server worker-address:3100;
+    }
+    upstream backend {
+        server worker-address:3100;
+    }
+    upstream worker {
+        server worker-address:3100;
+    }
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+    map $status $loggable {
+        ~^[23] 0;
+        default 1;
+    }
+    access_log /dev/stderr;
+    sendfile on;
+    tcp_nopush on;
+    resolver 198.18.0.0;
+    map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        '' anonymous;
+    }
+    proxy_read_timeout 300;
+    server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location = / {
+            return 200 "'OK'";
+            auth_basic off;
+        }
+        location = /status {
+            stub_status;
+        }
+        location = /loki/api/v1/push {
+            set $backend https://write;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /loki/api/v1/rules {
+            set $backend https://backend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /prometheus {
+            set $backend https://backend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /api/v1/rules {
+            set $backend https://backend/loki/api/v1/rules;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /loki/api/v1/tail {
+            set $backend https://read;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location ~ /loki/api/.* {
+            set $backend https://read;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection upgrade;
+        }
+        location = /loki/api/v1/format_query {
+            set $backend https://worker;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /loki/api/v1/status/buildinfo {
+            set $backend https://worker;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /ring {
+            set $backend https://worker;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+}

--- a/tests/test_coordinated_workers/resources/sample_mimir_nginx_conf.txt
+++ b/tests/test_coordinated_workers/resources/sample_mimir_nginx_conf.txt
@@ -1,0 +1,113 @@
+worker_processes 5;
+error_log /dev/stderr error;
+pid /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+events {
+    worker_connections 4096;
+}
+http {
+    upstream distributor {
+        server worker-address:8080;
+    }
+    upstream compactor {
+        server worker-address:8080;
+    }
+    upstream querier {
+        server worker-address:8080;
+    }
+    upstream query-frontend {
+        server worker-address:8080;
+    }
+    upstream ingester {
+        server worker-address:8080;
+    }
+    upstream ruler {
+        server worker-address:8080;
+    }
+    upstream store-gateway {
+        server worker-address:8080;
+    }
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+    map $status $loggable {
+        ~^[23] 0;
+        default 1;
+    }
+    access_log /dev/stderr;
+    sendfile on;
+    tcp_nopush on;
+    resolver 198.18.0.0;
+    map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        '' anonymous;
+    }
+    proxy_read_timeout 300;
+    server {
+        listen 8080;
+        listen [::]:8080;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location = / {
+            return 200 "'OK'";
+            auth_basic off;
+        }
+        location = /status {
+            stub_status;
+        }
+        location /distributor {
+            set $backend http://distributor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /api/v1/push {
+            set $backend http://distributor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /otlp/v1/metrics {
+            set $backend http://distributor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus/config/v1/rules {
+            set $backend http://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus/api/v1/rules {
+            set $backend http://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus/api/v1/alerts {
+            set $backend http://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /ruler/ring {
+            set $backend http://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus {
+            set $backend http://query-frontend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /api/v1/status/buildinfo {
+            set $backend http://query-frontend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /api/v1/upload/block/ {
+            set $backend http://compactor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+}

--- a/tests/test_coordinated_workers/resources/sample_mimir_nginx_conf_tls.txt
+++ b/tests/test_coordinated_workers/resources/sample_mimir_nginx_conf_tls.txt
@@ -1,0 +1,117 @@
+worker_processes 5;
+error_log /dev/stderr error;
+pid /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+events {
+    worker_connections 4096;
+}
+http {
+    upstream distributor {
+        server worker-address:8080;
+    }
+    upstream compactor {
+        server worker-address:8080;
+    }
+    upstream querier {
+        server worker-address:8080;
+    }
+    upstream query-frontend {
+        server worker-address:8080;
+    }
+    upstream ingester {
+        server worker-address:8080;
+    }
+    upstream ruler {
+        server worker-address:8080;
+    }
+    upstream store-gateway {
+        server worker-address:8080;
+    }
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+    map $status $loggable {
+        ~^[23] 0;
+        default 1;
+    }
+    access_log /dev/stderr;
+    sendfile on;
+    tcp_nopush on;
+    resolver 198.18.0.0;
+    map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        '' anonymous;
+    }
+    proxy_read_timeout 300;
+    server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location = / {
+            return 200 "'OK'";
+            auth_basic off;
+        }
+        location = /status {
+            stub_status;
+        }
+        location /distributor {
+            set $backend https://distributor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /api/v1/push {
+            set $backend https://distributor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /otlp/v1/metrics {
+            set $backend https://distributor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus/config/v1/rules {
+            set $backend https://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus/api/v1/rules {
+            set $backend https://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus/api/v1/alerts {
+            set $backend https://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /ruler/ring {
+            set $backend https://ruler;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location /prometheus {
+            set $backend https://query-frontend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /api/v1/status/buildinfo {
+            set $backend https://query-frontend;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+        location = /api/v1/upload/block/ {
+            set $backend https://compactor;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+}

--- a/tests/test_coordinated_workers/resources/sample_mimir_nginx_conf_tls.txt
+++ b/tests/test_coordinated_workers/resources/sample_mimir_nginx_conf_tls.txt
@@ -55,7 +55,7 @@ http {
         ssl_certificate /etc/nginx/certs/server.cert;
         ssl_certificate_key /etc/nginx/certs/server.key;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
-        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_ciphers HIGH:!aNULL:!MD5;z
         location = / {
             return 200 "'OK'";
             auth_basic off;

--- a/tests/test_coordinated_workers/resources/sample_tempo_nginx_conf.txt
+++ b/tests/test_coordinated_workers/resources/sample_tempo_nginx_conf.txt
@@ -1,0 +1,127 @@
+worker_processes 5;
+error_log /dev/stderr error;
+pid /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+events {
+    worker_connections 4096;
+}
+http {
+    upstream zipkin {
+        server worker-address:9411;
+    }
+    upstream otlp-grpc {
+        server worker-address:4317;
+    }
+    upstream otlp-http {
+        server worker-address:4318;
+    }
+    upstream jaeger-thrift-http {
+        server worker-address:14268;
+    }
+    upstream jaeger-grpc {
+        server worker-address:14250;
+    }
+    upstream tempo-http {
+        server worker-address:3200;
+    }
+    upstream tempo-grpc {
+        server worker-address:9096;
+    }
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+    map $status $loggable {
+        ~^[23] 0;
+        default 1;
+    }
+    access_log /dev/stderr;
+    sendfile on;
+    tcp_nopush on;
+    resolver 198.18.0.0;
+    map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        '' anonymous;
+    }
+    proxy_read_timeout 300;
+    server {
+        listen 9411;
+        listen [::]:9411;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://zipkin;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 4317 http2;
+        listen [::]:4317 http2;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend grpc://otlp-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 4318;
+        listen [::]:4318;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://otlp-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 14268;
+        listen [::]:14268;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://jaeger-thrift-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 14250 http2;
+        listen [::]:14250 http2;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend grpc://jaeger-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 3200;
+        listen [::]:3200;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend http://tempo-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 9096 http2;
+        listen [::]:9096 http2;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        location / {
+            set $backend grpc://tempo-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+}

--- a/tests/test_coordinated_workers/resources/sample_tempo_nginx_conf_tls.txt
+++ b/tests/test_coordinated_workers/resources/sample_tempo_nginx_conf_tls.txt
@@ -1,0 +1,155 @@
+worker_processes 5;
+error_log /dev/stderr error;
+pid /tmp/nginx.pid;
+worker_rlimit_nofile 8192;
+events {
+    worker_connections 4096;
+}
+http {
+    upstream zipkin {
+        server worker-address:9411;
+    }
+    upstream otlp-grpc {
+        server worker-address:4317;
+    }
+    upstream otlp-http {
+        server worker-address:4318;
+    }
+    upstream jaeger-thrift-http {
+        server worker-address:14268;
+    }
+    upstream jaeger-grpc {
+        server worker-address:14250;
+    }
+    upstream tempo-http {
+        server worker-address:3200;
+    }
+    upstream tempo-grpc {
+        server worker-address:9096;
+    }
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp_path;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    default_type application/octet-stream;
+    log_format main '$remote_addr - $remote_user [$time_local]  $status "$request" $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+    map $status $loggable {
+        ~^[23] 0;
+        default 1;
+    }
+    access_log /dev/stderr;
+    sendfile on;
+    tcp_nopush on;
+    resolver 198.18.0.0;
+    map $http_x_scope_orgid $ensured_x_scope_orgid {
+        default $http_x_scope_orgid;
+        '' anonymous;
+    }
+    proxy_read_timeout 300;
+    server {
+        listen 9411 ssl;
+        listen [::]:9411 ssl;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location / {
+            set $backend https://zipkin;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 4317 ssl http2;
+        listen [::]:4317 ssl http2;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location / {
+            set $backend grpcs://otlp-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 4318 ssl;
+        listen [::]:4318 ssl;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location / {
+            set $backend https://otlp-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 14268 ssl;
+        listen [::]:14268 ssl;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location / {
+            set $backend https://jaeger-thrift-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 14250 ssl http2;
+        listen [::]:14250 ssl http2;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location / {
+            set $backend grpcs://jaeger-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 3200 ssl;
+        listen [::]:3200 ssl;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location / {
+            set $backend https://tempo-http;
+            proxy_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+    server {
+        listen 9096 ssl http2;
+        listen [::]:9096 ssl http2;
+        proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+        server_name localhost;
+        ssl_certificate /etc/nginx/certs/server.cert;
+        ssl_certificate_key /etc/nginx/certs/server.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        location / {
+            set $backend grpcs://tempo-grpc;
+            grpc_pass $backend;
+            proxy_connect_timeout 5s;
+        }
+    }
+}

--- a/tests/test_coordinated_workers/test_coordinator.py
+++ b/tests/test_coordinated_workers/test_coordinator.py
@@ -12,6 +12,7 @@ from src.cosl.coordinated_workers.coordinator import (
     Coordinator,
     S3NotFoundError,
 )
+from src.cosl.coordinated_workers.nginx import NginxConfig
 from src.cosl.interfaces.cluster import ClusterRequirerAppData, ClusterRequirerUnitData
 from tests.test_coordinated_workers.test_worker import MyCharm
 
@@ -162,7 +163,7 @@ def coordinator_charm(request):
                     "receive-datasource": "my-ds-exchange-require",
                     "catalogue": None,
                 },
-                nginx_config=lambda coordinator: f"nginx configuration for {coordinator._charm.meta.name}",
+                nginx_config=NginxConfig("localhost", {}, {}),
                 workers_config=lambda coordinator: f"workers configuration for {coordinator._charm.meta.name}",
                 worker_ports=self._worker_ports,
                 # nginx_options: Optional[NginxMappingOverrides] = None,

--- a/tests/test_coordinated_workers/test_coordinator_status.py
+++ b/tests/test_coordinated_workers/test_coordinator_status.py
@@ -11,6 +11,7 @@ from scenario import BlockedStatus
 from scenario.context import CharmEvents
 
 from cosl.coordinated_workers.coordinator import ClusterRolesConfig, Coordinator
+from cosl.coordinated_workers.nginx import NginxConfig
 from cosl.interfaces.cluster import ClusterProviderAppData, ClusterRequirerAppData
 from tests.test_coordinated_workers.test_worker_status import k8s_patch
 
@@ -46,7 +47,7 @@ class MyCoordCharm(ops.CharmBase):
                 "catalogue": None,
                 "receive-datasource": "my-ds-exchange-require",
             },
-            nginx_config=lambda _: "nginx config",
+            nginx_config=NginxConfig("localhost", {}, {}),
             workers_config=lambda _: "worker config",
             resources_requests=lambda _: {"cpu": "50m", "memory": "100Mi"},
             container_name="charm",

--- a/tests/test_coordinated_workers/test_nginx.py
+++ b/tests/test_coordinated_workers/test_nginx.py
@@ -290,4 +290,4 @@ server_ports_to_locations = {
 
 
 def _get_nginx_config_params(workload: str) -> Tuple[list, dict]:
-    return (upstream_configs.get(workload), server_ports_to_locations.get(workload))
+    return upstream_configs[workload], server_ports_to_locations[workload]

--- a/tests/test_coordinated_workers/test_nginx.py
+++ b/tests/test_coordinated_workers/test_nginx.py
@@ -232,7 +232,7 @@ upstream_configs = {
         NginxUpstream("write", 3100, "write"),
         NginxUpstream("all", 3100, "all"),
         NginxUpstream("backend", 3100, "backend"),
-        NginxUpstream("worker", 3100, "worker"),
+        NginxUpstream("worker", 3100, "worker", ignore_worker_role=True),
     ],
 }
 server_ports_to_locations = {

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
     ruff
     codespell
 commands =
-    codespell {[vars]all_path}
+    codespell {[vars]all_path} --ignore-words-list=aNULL
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
@@ -72,7 +72,9 @@ commands =
 description = Run unit tests
 deps =
     .
-    deepdiff
+    # 8.4.2 is not working with python 3.8
+    # https://github.com/seperman/deepdiff/actions/runs/14816111179/job/41596774343
+    deepdiff<8.4.2
     fs
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ deps =
     PyYAML
     typing_extensions
     pyright
+    crossplane
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/lib
 commands =
@@ -72,9 +73,10 @@ commands =
 description = Run unit tests
 deps =
     .
-    # 8.4.2 is not working with python 3.8
-    # https://github.com/seperman/deepdiff/actions/runs/14816111179/job/41596774343
-    deepdiff<8.4.2
+    # for deepdiff 8.4.2 to work
+    # https://github.com/seperman/deepdiff/issues/539
+    orderly-set==5.3.0
+    deepdiff
     fs
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,7 @@ deps =
     cryptography
     jsonschema
     PyYAML
+    crossplane
 allowlist_externals =
     /usr/bin/env
     charmcraft


### PR DESCRIPTION
## Issue
All our (HA) coordinators generate their own nginx config from scratch although they share a lot of common config.

## Solution
Extract all shared configuration into `cosl`, and keep only the coordinator-specific parts of the `upstreams` and `locations` blocks, which each coordinator will pass to the shared object as needed.

## Context
- We do nginx config generation using `crossplane`, so we lazy load it inside `NginxConfig` to avoid adding a new dependency to `cosl`

## Testing Instructions
Tandem PRs:
- https://github.com/canonical/tempo-coordinator-k8s-operator/pull/155
- https://github.com/canonical/loki-coordinator-k8s-operator/pull/52
- https://github.com/canonical/parca-k8s-operator/pull/444
- https://github.com/canonical/mimir-coordinator-k8s-operator/pull/130


## Upgrade Notes
- This introduces a breaking change to the coordinated workers. The coordinator used to accept `nginx_config: Callable[["Coordinator"], str]`, but in order to avoid getting this messy with custom conditions/checks, we can just replace it with a different expected input. (We can make it backwards-compatible if we need to, but at some point we'd need to have a breaking change anyways :D)
