### PR TITLE
Deprecate `coordinated_workers` module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/coordinated_workers/__init__.py
+++ b/src/cosl/coordinated_workers/__init__.py
@@ -4,6 +4,12 @@
 """Utils for observability Juju charms."""
 
 import importlib
+import warnings
+
+warnings.warn(
+    "The `coordinated_workers` module will be removed from `cosl`. Please migrate to `https://github.com/canonical/cos-coordinated-workers`.",
+    DeprecationWarning,
+)
 
 __all__ = [
     "Coordinator",


### PR DESCRIPTION
Add a deprecation notice for `coordinated_workers` module in preparation for its migration to a standalone library.

## Context
https://github.com/canonical/cos-lib/pull/146


