### PR TITLE
feat: add statuses based on free disk space

### DIFF
--- a/src/cosl/statuses.py
+++ b/src/cosl/statuses.py
@@ -17,16 +17,20 @@ def get_disk_usage_status(location: str, *, threshold: int = 1024**3) -> ops.Sta
     """Returns a status that matches the disk usage.
 
     Returns:
-     - ActiveStatus when the provided <location> has more <threshold> bytes;
+     - ActiveStatus when the provided <location> has more than <threshold> free bytes;
      - BlockedStatus when <location> is below <threshold>;
      - MaintenanceStatus when the <location> is not found i.e. before storage is attached.
+
+    Args:
+        location (str): The file system path to check for available disk space e.g. /var/lib/prometheus. In most cases, the charm calling this function would get this by calling self.model.storages["database"][0].location.
+        threshold (int): The minimum number of free bytes required before blocking. The default is 1024**3.
     """
     try:
         # NOTE: we measure the disk space from the charm container because it shares the same storage as the workload container
         free_disk_space = shutil.disk_usage(location).free
         if free_disk_space < threshold:
-            logger.warning(f"Less than 1GiB of disk space remaining in {location}")
-            return ops.BlockedStatus("<1 GiB remaining")
+            logger.warning(f"Less than {threshold} bytes of disk space remaining in {location}")
+            return ops.BlockedStatus(f"<{threshold / 1024**3:.1g} GiB remaining")
 
         else:
             return ops.ActiveStatus()

--- a/tests/test_get_disk_status.py
+++ b/tests/test_get_disk_status.py
@@ -24,5 +24,22 @@ def test_get_disk_usage_status(free_space, expected_status):
     with patch("shutil.disk_usage") as mock_disk_usage:
         mock_disk_usage.return_value.free = free_space
         unit_status = get_disk_usage_status(location="/foo/bar")
-
         assert type(unit_status) is type(expected_status)
+
+
+def test_get_maintenance_status_when_storage_not_attached():
+    unit_status = get_disk_usage_status(location="foo/bar")
+    assert type(unit_status) is type(ops.MaintenanceStatus())
+
+
+@pytest.mark.parametrize(
+    "free_space,threshold,expected_status",
+    [
+        (1024**3, 1024**4, ops.BlockedStatus("<1e+03 GiB remaining")),
+    ],
+)
+def test_blocked_status_message(free_space, threshold, expected_status):
+    with patch("shutil.disk_usage") as mock_disk_usage:
+        mock_disk_usage.return_value.free = free_space
+        unit_status = get_disk_usage_status(location="/foo/bar", threshold=threshold)
+        assert unit_status == expected_status


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
This PR fixes #152.

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Adds function which accepts the location of storage and the threshold and returns an appropriate status based on the comparison.
2. Adds unit tests for this logic.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Please review the attached issue (#152) on why this change is being implemented. The idea is that other charms would import this functionality from `cosl` and use it `on_collect_unit_status` to check whether to set status blocked based on whether there is sufficient space remaining or not. The charm has to be blocked if remaining storage is < 1GiB.
## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
The unit test added must pass (and it does).

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
