### PR TITLE
feat: add time validation module

### DIFF
--- a/src/cosl/time_validation.py
+++ b/src/cosl/time_validation.py
@@ -4,6 +4,8 @@
 
 import re
 
+_VALID_TIMESPEC_RE = re.compile(r"^(0|[0-9]+(y|w|d|h|m|s|ms))$")
+
 
 def is_valid_timespec(timeval: str) -> bool:
     """Returns a boolean based on whether the passed parameter is a valid timespec.
@@ -26,8 +28,4 @@ def is_valid_timespec(timeval: str) -> bool:
         - ms for milliseconds.
         Otherwise, it returns False.
     """
-    timespec_re = re.compile(
-        r"^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$"
-    )
-    matched = timespec_re.search(timeval)
-    return bool(matched)
+    return bool(_VALID_TIMESPEC_RE.match(timeval))

--- a/tests/test_time_validation.py
+++ b/tests/test_time_validation.py
@@ -20,6 +20,7 @@ from cosl.time_validation import is_valid_timespec
         ("1s", True),
         ("1ms", True),
         ("1sdgs", False),
+        ("1w2d", False),
         ("one week", False),
         ("one hour", False),
     ],


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Certain COS charms such as [Prometheus](https://github.com/canonical/prometheus-k8s-operator/blob/4683c8ff32523dc91d7e5e92e767ae044d00a24a/src/charm.py#L958) and [Mimir](https://github.com/canonical/mimir-coordinator-k8s-operator/blob/ecf4ced78ee84b24ec98944b266cf2fb7a8630b9/src/charm.py#L374C5-L376C1) perform time spec validation to validate user set config values related to retention period. Since this check is identical for both of them, it is being added to `cos-lib` to reduce duplication.

## Solution
<!-- A summary of the solution addressing the above issue -->
A function is added with the following spec:
```
Returns a boolean based on whether the passed parameter is a valid timespec.
        Upstream ref: https://github.com/prometheus/prometheus/blob/c40e269c3e514953299e9ba1f6265e067ab43e64/cmd/prometheus/main.go#L302
        
        Args:
            timeval: a string representing a time specification .e.g "1d", "1w"

        Returns:
            True if time specification is valid and False otherwise.
            The regex in this function returns True when the parameter is 0 or when it uses one of the following units:
            - y for years
            - m for months
            - w for weeks
            - d for days
            - h for hour
            - m for minutes
            - s for seconds
            - ms for milliseconds
            Otherwise, it returns False
```

A test is also added that ensures the check works as intended.
## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
