### PR TITLE
feat: Cosl owns `type_convert_stored`

### DIFF
--- a/src/cosl/types.py
+++ b/src/cosl/types.py
@@ -1,8 +1,10 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Types used by cos-lib."""
-from typing import Dict, List, Literal, Optional, TypedDict, Union
 
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+
+from ops.framework import StoredDict, StoredList
 from typing_extensions import Required
 
 QueryType = Literal["logql", "promql"]
@@ -43,3 +45,17 @@ class OfficialRuleFileFormat(TypedDict):
     """
 
     groups: List[OfficialRuleFileItem]
+
+
+def type_convert_stored(
+    obj: Union[StoredList, StoredDict, Any],
+) -> Union[List[Any], Dict[Any, Any], Any]:
+    """Convert Stored* to their appropriate types, recursively."""
+    if isinstance(obj, StoredList):
+        return list(map(type_convert_stored, obj))
+    if isinstance(obj, StoredDict):
+        rdict: Dict[Any, Any] = {}
+        for k in obj.keys():
+            rdict[k] = type_convert_stored(obj[k])
+        return rdict
+    return obj

--- a/src/cosl/types.py
+++ b/src/cosl/types.py
@@ -50,7 +50,10 @@ class OfficialRuleFileFormat(TypedDict):
 def type_convert_stored(
     obj: Union[StoredList, StoredDict, Any],
 ) -> Union[List[Any], Dict[Any, Any], Any]:
-    """Convert Stored* to their appropriate types, recursively."""
+    """Helper for converting Stored[Dict|List|Set] to the objects they pretend to be.
+
+    Ref: https://github.com/canonical/operator/pull/572
+    """
     if isinstance(obj, StoredList):
         return list(map(type_convert_stored, obj))
     if isinstance(obj, StoredDict):

--- a/tests/test_type_convert_stored.py
+++ b/tests/test_type_convert_stored.py
@@ -14,15 +14,34 @@ def test_converting_stored_types():
     assert type_convert_stored(StoredDict({}, under={1: 2})) == {1: 2}
 
     # GIVEN nested structures and mixed types
-    assert type_convert_stored(StoredList({}, under=[1, StoredList({}, under=[3, 4])])) == [1, [3, 4]]
-    assert type_convert_stored(StoredDict({}, under={1: StoredList({}, under=[3, 4])})) == {1: [3, 4]}
-    assert type_convert_stored(StoredDict({}, under={1: StoredDict({}, under={2: 3})})) == {1: {2: 3}}
-    assert type_convert_stored(StoredList({}, under=[1, StoredDict({}, under={2: 3})])) == [1, {2: 3}]
+    assert type_convert_stored(StoredList({}, under=[1, StoredList({}, under=[3, 4])])) == [
+        1,
+        [3, 4],
+    ]
+    assert type_convert_stored(StoredDict({}, under={1: StoredList({}, under=[3, 4])})) == {
+        1: [3, 4]
+    }
+    assert type_convert_stored(StoredDict({}, under={1: StoredDict({}, under={2: 3})})) == {
+        1: {2: 3}
+    }
+    assert type_convert_stored(StoredList({}, under=[1, StoredDict({}, under={2: 3})])) == [
+        1,
+        {2: 3},
+    ]
 
     # GIVEN non-standard types
-    assert type_convert_stored(StoredDict({}, under={1: "string", 2: 3.5})) == {1: "string", 2: 3.5}
+    assert type_convert_stored(StoredDict({}, under={1: "string", 2: 3.5})) == {
+        1: "string",
+        2: 3.5,
+    }
     assert type_convert_stored(StoredList({}, under=[None, True, False])) == [None, True, False]
 
     # GIVEN deeply nested structures
-    assert type_convert_stored(StoredDict({}, under={1: StoredList({}, under=[StoredDict({}, under={2: StoredList({}, under=[5])})])})) == {1: [{2: [5]}]}
-
+    assert type_convert_stored(
+        StoredDict(
+            {},
+            under={
+                1: StoredList({}, under=[StoredDict({}, under={2: StoredList({}, under=[5])})])
+            },
+        )
+    ) == {1: [{2: [5]}]}

--- a/tests/test_type_convert_stored.py
+++ b/tests/test_type_convert_stored.py
@@ -4,7 +4,25 @@ from cosl.types import type_convert_stored
 
 
 def test_converting_stored_types():
+    # GIVEN empty structures
+    assert type_convert_stored(StoredDict({}, under={})) == {}
+    assert type_convert_stored(StoredList({}, under=[])) == []
+
+    # GIVEN simple key-value pairs
     assert type_convert_stored(StoredDict({}, under={1: {}})) == {1: {}}
     assert type_convert_stored(StoredDict({}, under={1: []})) == {1: []}
     assert type_convert_stored(StoredDict({}, under={1: 2})) == {1: 2}
-    assert type_convert_stored(StoredList({}, under=[1, 2])) == [1, 2]
+
+    # GIVEN nested structures and mixed types
+    assert type_convert_stored(StoredList({}, under=[1, StoredList({}, under=[3, 4])])) == [1, [3, 4]]
+    assert type_convert_stored(StoredDict({}, under={1: StoredList({}, under=[3, 4])})) == {1: [3, 4]}
+    assert type_convert_stored(StoredDict({}, under={1: StoredDict({}, under={2: 3})})) == {1: {2: 3}}
+    assert type_convert_stored(StoredList({}, under=[1, StoredDict({}, under={2: 3})])) == [1, {2: 3}]
+
+    # GIVEN non-standard types
+    assert type_convert_stored(StoredDict({}, under={1: "string", 2: 3.5})) == {1: "string", 2: 3.5}
+    assert type_convert_stored(StoredList({}, under=[None, True, False])) == [None, True, False]
+
+    # GIVEN deeply nested structures
+    assert type_convert_stored(StoredDict({}, under={1: StoredList({}, under=[StoredDict({}, under={2: StoredList({}, under=[5])})])})) == {1: [{2: [5]}]}
+

--- a/tests/test_type_convert_stored.py
+++ b/tests/test_type_convert_stored.py
@@ -1,0 +1,10 @@
+from ops.framework import StoredDict, StoredList
+
+from cosl.types import type_convert_stored
+
+
+def test_converting_stored_types():
+    assert type_convert_stored(StoredDict({}, under={1: {}})) == {1: {}}
+    assert type_convert_stored(StoredDict({}, under={1: []})) == {1: []}
+    assert type_convert_stored(StoredDict({}, under={1: 2})) == {1: 2}
+    assert type_convert_stored(StoredList({}, under=[1, 2])) == [1, 2]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Many of our libs own the `_type_convert_stored` method:
- graf_dashboard
- graf_datasource
- prom_scrape
- nrpe_exporter
- graf_auth
- ingress_per_unit

This is code duplication.

## Solution
<!-- A summary of the solution addressing the above issue -->
Cosl now owns this and should be imported from in all our libs.

We know that this function works because it is duplicated in all our libraries and I copied it over. The only difference being additional type checking to pass `cosl` static checks and making it public:

<img width="1409" height="369" alt="image" src="https://github.com/user-attachments/assets/5e26c89c-d8c6-4674-a969-598cb0759f81" />