### PR TITLE
fix: Adds type_convert_stored to __init__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/__init__.py
+++ b/src/cosl/__init__.py
@@ -8,6 +8,7 @@ from .grafana_dashboard import DashboardPath40UID, GrafanaDashboard, LZMABase64
 from .juju_topology import JujuTopology
 from .mandatory_relation_pairs import MandatoryRelationPairs
 from .rules import AlertRules, RecordingRules
+from .types import type_convert_stored
 
 __all__ = [
     "JujuTopology",
@@ -18,4 +19,5 @@ __all__ = [
     "AlertRules",
     "RecordingRules",
     "MandatoryRelationPairs",
+    "type_convert_stored",
 ]


### PR DESCRIPTION
Fixes [import issue](https://github.com/canonical/cos-coordinated-workers/actions/runs/18315236938/job/52220256745?pr=93):
````
from cosl.types import type_convert_stored
E   ImportError: cannot import name 'type_convert_stored' from 'cosl.types' (/home/runner/.cache/uv/builds-v0/.tmpf7uD75/lib/python3.8/site-packages/cosl/types.py)
```