### PR TITLE
fix: make generic alert rules more detailed

### DIFF
--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -105,8 +105,7 @@ _generic_alert_rules: Final = SimpleNamespace(
         "labels": {"severity": "critical"},
         "annotations": {
             "summary": "Host '{{ $labels.instance }}' is down.",
-            "description": """Juju application '{{ $labels.juju_application }}' in model '{{ $labels.juju_model }}' is down.
-            Prometheus has been unable to scrape it during at least the past five minutes.""",
+            "description": "Juju application '{{ $labels.juju_application }}' in model '{{ $labels.juju_model }}' is down. Prometheus has been unable to scrape it during at least the past five minutes.",
         },
     },
     host_metrics_missing={
@@ -117,11 +116,8 @@ _generic_alert_rules: Final = SimpleNamespace(
         "for": "5m",
         "labels": {"severity": "critical"},
         "annotations": {
-            "summary": "Metrics not received from charm '{{ $labels.juju_application }}'. Remote writing of metrics has failed.",
-            "description": """
-                Juju application '{{ $labels.juju_application }}' in model '{{ $labels.juju_model }}'
-                has failed to remote write metrics into Prometheus since at least the past 5 minutes.
-            """,
+            "summary": "Metrics not received from application '{{ $labels.juju_application }}'. Remote writing of metrics has failed.",
+            "description": "`Up` missing for application {{ $labels.juju_application }} in model {{ $labels.juju_model }}.  This can mean that the collector scraping metrics from this charm has been unable to remote write its collected metrics into Prometheus. Oftentimes, when the collector is failing to remote write the collected metrics, the HostMetricsMissing alert for it will also be triggered. Please check the collector's logs and ensure it is able to successfully hit the Prometheus remote write endpoint.",
         },
     },
 )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #164.

## Solution
<!-- A summary of the solution addressing the above issue -->
Adds more context in the annotation of the `HostDown` and `HostMetricsMissing` alerts and ensures they do not reference the instance. This is especially important for `HostMetricsMissing` as this impacts remote writes and Prometheus does not add any instance when metrics are remote written (as opposed to scrapes, for which Prometheus adds instance + job).
## For `HostDown`
<img width="1669" height="157" alt="image" src="https://github.com/user-attachments/assets/7ac1ef5a-e17c-4bba-9782-87263269b6a5" />


## For `HostMetricsMissing`
<img width="1670" height="261" alt="image" src="https://github.com/user-attachments/assets/7880e3ba-a3c8-48c6-8711-302aa04daf48" />

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
