### PR TITLE
feat: add `aggregator metrics missing` rule

### DIFF
--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -94,7 +94,7 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-AGGREGATOR_METRICS_MISSING_RULE_NAME = "AggregatorMetricsMissing"
+HOST_METRICS_MISSING_RULE_NAME = "HostMetricsMissing"
 
 _generic_alert_rules: Final = SimpleNamespace(
     # We use "5m" to avoid false positives on expected temporary "down", e.g. during intentional (re)start.
@@ -110,7 +110,7 @@ _generic_alert_rules: Final = SimpleNamespace(
         },
     },
     host_metrics_missing={
-        "alert": "HostMetricsMissing",
+        "alert": HOST_METRICS_MISSING_RULE_NAME,
         "expr": "absent(up)",
         "for": "5m",
         "labels": {
@@ -122,7 +122,7 @@ _generic_alert_rules: Final = SimpleNamespace(
         },
     },
     aggregator_metrics_missing={
-        "alert": AGGREGATOR_METRICS_MISSING_RULE_NAME,
+        "alert": "AggregatorMetricsMissing",
         "expr": "absent(up)",
         "for": "5m",
         "labels": {"severity": "critical"},


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #168 and partially fixes #165.

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Adds a new aggregator rule called `AggregatorMetricsMissing`. This will have severity=critical and will fire when all units of a remote writer are down or failing to remote write.
2. Modifies the existing rule called `HostMetricsMissing` so that it will be unit level alert. This means that it will be dedicated to a single unit of an app and fires when that specific unit is down or failing to remote write. It will have severity warning for K8s units and critical for machine units.
After this PR goes through, https://github.com/canonical/prometheus-k8s-operator/pull/748 will need to be modified so it checks charm type and appropriately sets the severity level in (2). 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
