### PR TITLE
feat: Add ActionEvent to all_events

### DIFF
--- a/src/cosl/reconciler.py
+++ b/src/cosl/reconciler.py
@@ -51,6 +51,7 @@ all_events: Final[Set[Type[ops.EventBase]]] = {
     ops.charm.StopEvent,
     ops.charm.UpgradeCharmEvent,
     ops.charm.PebbleCustomNoticeEvent,
+    ops.charm.ActionEvent,
 }
 
 # reconcilable_events_k8s is a list of all_events EXCEPT those listed below.


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We are missing the reconcile event in the `all_events` list. This is blocking this PR:
- https://github.com/canonical/opentelemetry-collector-operator/pull/168

since the otelcol charm has a `reconcile` action that we want to reconcile on.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add it as an event.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
All implementations of the `cosl.reconciler` will now also reconcile on charm actions