### PR TITLE
chore: Bump version to 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "1.3.1"
+version = "1.5.0"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]


### PR DESCRIPTION
Pyproject.toml version was outdated, bumping it.