### PR TITLE
refactor: InjectResult and SingleRuleFormat types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "1.8.0"
+version = "1.9.0"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/rules.py
+++ b/src/cosl/rules.py
@@ -214,12 +214,10 @@ class InjectResult:
 
     Attributes:
         rules: The (possibly injected) rules dictionary.
-        identifier: The topology/group identifier discovered for these rules.
         errmsg: Optional error message produced during validation.
     """
 
     rules: OfficialRuleFileFormat
-    identifier: Optional[str]
     errmsg: Optional[str]
 
 
@@ -416,10 +414,11 @@ class Rules:
         if not rule_dict:
             raise ValueError("Empty")
 
-        if self._is_official_rule_format(rule_dict):
-            groups = [OfficialRuleFileItem(**g) for g in rule_dict.get("groups", [])]
-        elif self._is_single_rule_format(rule_dict):
-            single_rule = cast(SingleRuleFormat, rule_dict)
+        rule_copy = copy.deepcopy(rule_dict)
+        if self._is_official_rule_format(rule_copy):
+            groups = [OfficialRuleFileItem(**g) for g in rule_copy.get("groups", [])]
+        elif self._is_single_rule_format(rule_copy):
+            single_rule = cast(SingleRuleFormat, rule_copy)
             if not group_name:
                 # Note: the caller of this function should ensure this never happens:
                 # Either we use the standard format, or we'd pass a group_name.
@@ -533,37 +532,28 @@ class Rules:
     ) -> InjectResult:
         """Inject Juju topology labels and validate rules using CosTool.
 
-        The returned identifier is useful for grouping rules by topology on disk.
-
         Args:
             rules: a single-rule or official-rule mapping
             metadata: Juju topology metadata to inject into the rules, if
                 labels are not already present
         Returns:
-            An InjectResult with the possibly-injected rules, the
-            discovered identifier (or None), and an optional error message if
-            validation failed.
+            An InjectResult with the possibly-injected rules and an optional
+            error message if validation failed.
         """
+        if not rules:
+            return InjectResult(rules=OfficialRuleFileFormat(groups=[]), errmsg=None)
+
         topology = None
         with contextlib.suppress(KeyError):
             topology = JujuTopology.from_dict(metadata)
 
         # Inject juju topology labels and sanitize rules
         rules_data = OfficialRuleFileFormat(groups=self._from_dict(rules, metadata=topology))
-        topology_ctx = topology or self.topology
-        identifier = topology_ctx.identifier if topology_ctx else None
-        if not identifier:
-            return InjectResult(
-                rules=rules_data,
-                identifier=identifier,
-                errmsg=f"{self.query_type} rules were found, but an identifier was not available from rule labels or metadata.",
-            )
-
         valid_rules, errmsg = self.tool.validate_alert_rules(rules_data)
         if not valid_rules:
-            return InjectResult(rules=rules_data, identifier=identifier, errmsg=errmsg)
+            return InjectResult(rules=rules_data, errmsg=errmsg)
 
-        return InjectResult(rules=rules_data, identifier=identifier, errmsg=None)
+        return InjectResult(rules=rules_data, errmsg=None)
 
 
 class AlertRules(Rules):

--- a/src/cosl/types.py
+++ b/src/cosl/types.py
@@ -12,36 +12,42 @@ RuleType = Literal["alert", "record"]
 RULE_TYPES: Final = frozenset({"alert", "record"})
 
 
-class RecordingRuleFormat(TypedDict):
-    """A custom single rule format for recording rules.
+RecordingRuleFormat = TypedDict(
+    "RecordingRuleFormat",
+    {
+        "record": Required[str],
+        "expr": Required[str],
+        "labels": NotRequired[Dict[str, str]],
+    },
+)
+"""A custom single rule format for recording rules.
 
-    The official format is a YAML file conforming to the Prometheus/Cortex documentation
-    (https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
-    The custom single rule format is a subsection of the official YAML, having a single recording
-    rule, effectively "one record per file".
-    """
-
-    record: Required[str]
-    expr: Required[str]
-    labels: NotRequired[Dict[str, str]]
+The official format is a YAML file conforming to the Prometheus/Cortex documentation
+(https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
+The custom single rule format is a subsection of the official YAML, having a single recording
+rule, effectively "one record per file".
+"""
 
 
-class AlertingRuleFormat(TypedDict):
-    """A custom single rule format for alerting rules.
+AlertingRuleFormat = TypedDict(
+    "AlertingRuleFormat",
+    {
+        "alert": Required[str],
+        "expr": Required[str],
+        "duration": NotRequired[str],
+        "for": NotRequired[str],
+        "keep_firing_for": NotRequired[str],
+        "labels": NotRequired[Dict[str, str]],
+        "annotations": NotRequired[Dict[str, str]],
+    },
+)
+"""A custom single rule format for alerting rules.
 
-    The official format is a YAML file conforming to the Prometheus/Cortex documentation
-    (https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
-    The custom single rule format is a subsection of the official YAML, having a single alert
-    rule, effectively "one alert per file".
-    """
-
-    alert: Required[str]
-    expr: Required[str]
-    duration: NotRequired[str]
-    for_: NotRequired[str]
-    keep_firing_for: NotRequired[str]
-    labels: NotRequired[Dict[str, str]]
-    annotations: NotRequired[Dict[str, str]]
+The official format is a YAML file conforming to the Prometheus/Cortex documentation
+(https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
+The custom single rule format is a subsection of the official YAML, having a single alert
+rule, effectively "one alert per file".
+"""
 
 
 SingleRuleFormat = Union[AlertingRuleFormat, RecordingRuleFormat]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Cleanup for this PR:
- https://github.com/canonical/charmlibs/pull/392

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Copy the rules when executing `_from_dict` to avoid side-effecting.
2. Remove the identifier logic from the `inject_and_validate` method. OTLP is the only one that uses it.
3. Update the `SingleRulesFormat` types so that we can be explicit with the keys of the `TypedDict` e.g., `for: foo` is not a valid key because it clashed with the reserved for loop command.

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
- [x] This change warrants a release, so I have updated the `project.version` field in the `pyproject.toml` file.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Tested by pulling these changes in the `.venv` of the charmlibs PR and checking for passing tests.
