### PR TITLE
feat: persist the cos-tool result cache across processes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "1.10.1"
+version = "1.10.2"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]
@@ -18,6 +18,7 @@ dependencies = [
     "tenacity",
     "PyYAML",
     "typing-extensions",
+    "diskcache",
 ]
 
 classifiers = [

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -8,11 +8,11 @@ import platform
 import re
 import subprocess
 import tempfile
-from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import yaml
+from diskcache import Cache  # pyright: ignore[reportMissingTypeStubs]
 from typing_extensions import TypeVar
 
 from .types import OfficialRuleFileFormat, QueryType
@@ -21,41 +21,76 @@ logger = logging.getLogger(__name__)
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
-# Upper bound for the memoization cache of cos-tool invocations. cos-tool is invoked
-# once per alert expression, and the same expressions are frequently reprocessed
-# (e.g. bundled rules across many related applications, or the same rules staged then
-# forwarded to several backends). A bounded LRU cache avoids the (dominant) subprocess
-# spawn + pipe-read overhead while keeping memory usage bounded in long-lived processes.
-_EXEC_CACHE_MAXSIZE = 2048
+# Upper bound (in bytes) for the on-disk cos-tool result cache. cos-tool is invoked once
+# per alert expression and its (deterministic) results are memoized to avoid the dominant
+# cost: the subprocess spawn (~tens of ms) on every reconcile. diskcache evicts least-
+# recently-used entries once this size is exceeded, so the cache never grows unbounded
+# while staying "hot" for the expressions actually in use. Entries are short strings, so
+# this comfortably holds the distinct expressions of a large (hundreds of apps)
+# aggregation deployment with room to grow.
+_EXEC_CACHE_SIZE_LIMIT = 256 * 1024 * 1024  # 256 MiB
+
+# Module-level, process-wide cache shared by all CosTool instances: cos-tool results
+# depend only on their inputs, not on which instance produced them, so results are
+# reusable across the many short-lived instances created during rule processing.
+#
+# Until configured with a persistent directory, it uses a temporary directory that lives
+# for the process (like the previous in-memory memoization). ``configure_cache`` points
+# it at persistent storage so results survive across process invocations (each Juju event
+# is a fresh process, which would otherwise always start cold).
+_exec_cache = Cache(size_limit=_EXEC_CACHE_SIZE_LIMIT)
 
 
-@lru_cache(maxsize=_EXEC_CACHE_MAXSIZE)
-def _cached_exec(cmd: Tuple[str, ...]) -> str:
-    """Run a cos-tool command and memoize its output.
+def configure_cache(cache_dir: Optional[Union[str, Path]]) -> None:
+    """Enable on-disk persistence of the cos-tool result cache.
 
-    `cos-tool transform` / `validate` are pure, deterministic functions of their
-    argument list (tool path + flags + expression/rule file), so identical
-    invocations can be memoized.
+    By default the cache lives in a temporary directory and starts cold in every process.
+    Charms that reconcile on every Juju event spawn a fresh process each time, so they
+    never benefit from a previous run's work. Point this at a persistent directory (e.g. a
+    charm's persistent storage mount) to carry the cache across process invocations.
 
-    Note:
-        The result depends on the cos-tool binary at the path embedded in ``cmd``.
-        The binary is assumed immutable for the lifetime of the process. Call
-        :func:`clear_exec_cache` if that assumption is ever violated.
+    Passing ``None`` reverts to a process-local temporary cache.
+
+    Args:
+        cache_dir: directory in which to store the cache, or ``None`` for a temporary one.
     """
-    result = subprocess.run(
-        list(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    )
-    return result.stdout.decode("utf-8").strip()
+    global _exec_cache
+    directory = str(cache_dir) if cache_dir is not None else None
+    _exec_cache.close()
+    _exec_cache = Cache(directory=directory, size_limit=_EXEC_CACHE_SIZE_LIMIT)
 
 
 def clear_exec_cache() -> None:
     """Clear the memoization cache of cos-tool invocations.
 
-    Charms that reconcile their whole state on every event may call this at the start
-    of a reconciliation to bound the cache to a single reconciliation, though the
-    bounded LRU size already prevents unbounded growth.
+    Charms that reconcile their whole state on every event may call this at the start of a
+    reconciliation to bound the cache to a single reconciliation, though the size limit
+    already prevents unbounded growth.
     """
-    _cached_exec.cache_clear()
+    _exec_cache.clear()
+
+
+def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
+    """Run a cos-tool command, memoizing its (deterministic) output.
+
+    Args:
+        cmd: the cos-tool command to run on a cache miss.
+        cache_key: a deterministic key identifying the invocation. Defaults to ``cmd``;
+            pass an explicit key for commands that reference a nondeterministic path
+            (e.g. the tempfile used by ``validate_alert_rules``), so the cache still hits.
+    """
+    key = tuple(cache_key) if cache_key is not None else tuple(cmd)
+    # diskcache ships no type stubs, so ``get``/``set`` are untyped; we only ever store
+    # ``str`` under these keys, so cast the retrieved value back to ``str``.
+    cached = cast(Optional[str], _exec_cache.get(key))  # pyright: ignore[reportUnknownMemberType]
+    if cached is not None:
+        return cached
+    result = subprocess.run(
+        list(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+    output = result.stdout.decode("utf-8").strip()
+    _exec_cache.set(key, output)  # pyright: ignore[reportUnknownMemberType]
+    return output
 
 
 def ensure_querytype(func: _F) -> _F:
@@ -158,12 +193,24 @@ class CosTool:
 
                 rules = transformed_rules
 
-            rule_path.write_text(yaml.dump(rules))
+            rules_yaml = yaml.dump(rules)
+            rule_path.write_text(rules_yaml)
 
             args = [str(self.path), "--format", query_type, "validate", str(rule_path)]
+            # The tempfile path is nondeterministic, so it must not be part of the cache
+            # key or validation would never be memoized. Key on the rule *content*
+            # instead: validation is a pure function of the binary, format and rules.
+            cache_key = (
+                str(self.path),
+                "--format",
+                query_type,
+                "validate",
+                "--content",
+                rules_yaml,
+            )
             # noinspection PyBroadException
             try:
-                self._exec(args)  # type: ignore
+                self._exec(args, cache_key=cache_key)  # type: ignore
                 return True, ""
             except subprocess.CalledProcessError as e:
                 logger.debug("Validating the rules failed: %s", e.output.decode("utf-8"))
@@ -228,9 +275,14 @@ class CosTool:
             logger.debug('Could not locate cos-tool at: "{}"'.format(res))
         return None
 
-    def _exec(self, cmd: List[str]) -> str:
-        # Delegate to a module-level, memoized worker. The result depends only on the
-        # command (not on instance state), so identical invocations across the many
-        # short-lived CosTool instances created during rule processing are deduplicated,
-        # avoiding redundant subprocess spawns.
-        return _cached_exec(tuple(cmd))
+    def _exec(self, cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
+        # Delegate to the module-level, memoized worker. The result depends only on the
+        # command inputs (not on instance state), so identical invocations across the
+        # many short-lived CosTool instances created during rule processing are
+        # deduplicated, avoiding redundant subprocess spawns.
+        #
+        # ``cache_key`` lets callers memoize on something other than ``cmd`` itself,
+        # which matters for commands that reference a nondeterministic path (e.g. the
+        # tempfile used by ``validate_alert_rules``): keying on the file path would
+        # never hit, so those callers pass a content-derived key instead.
+        return _exec(cmd, cache_key=cache_key)

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -38,14 +38,19 @@ _EXEC_CACHE_SIZE_LIMIT = 256 * 1024 * 1024  # 256 MiB
 # use ``configure_cache`` with real persistent storage when that matters.
 _DEFAULT_CACHE_DIR = "/tmp/cosl-cos-tool"  # noqa: S108
 
-# Module-level, process-wide cache shared by all CosTool instances: cos-tool results
-# depend only on their inputs, not on which instance produced them, so results are
-# reusable across the many short-lived instances created during rule processing.
-#
-# It defaults to a fixed on-disk directory (see ``_DEFAULT_CACHE_DIR``). ``configure_cache``
-# points it at a different (e.g. charm-persistent) directory so results survive beyond what
-# ``/tmp`` offers (each Juju event is a fresh process, which would otherwise start cold).
-_exec_cache = Cache(directory=_DEFAULT_CACHE_DIR, size_limit=_EXEC_CACHE_SIZE_LIMIT)
+# The cache is opened lazily (see ``_get_cache``) rather than at import, so importing this
+# module has no filesystem side effects (no directory creation, no failure on a read-only
+# or permission-restricted ``/tmp``). Only the target directory is held at module scope.
+_cache_dir: str = _DEFAULT_CACHE_DIR
+_exec_cache: Optional[Cache] = None
+
+
+def _get_cache() -> Cache:
+    """Return the process-wide cache, opening it at ``_cache_dir`` on first use."""
+    global _exec_cache
+    if _exec_cache is None:
+        _exec_cache = Cache(directory=_cache_dir, size_limit=_EXEC_CACHE_SIZE_LIMIT)
+    return _exec_cache
 
 
 def configure_cache(cache_dir: Optional[Union[str, Path]]) -> None:
@@ -57,15 +62,17 @@ def configure_cache(cache_dir: Optional[Union[str, Path]]) -> None:
     (e.g. a charm's persistent storage mount) to carry the cache across process invocations
     reliably.
 
-    Passing ``None`` reverts to the default shared location.
+    Passing ``None`` reverts to the default shared location. The cache is (re)opened lazily
+    on next use, so this never creates directories eagerly.
 
     Args:
         cache_dir: directory in which to store the cache, or ``None`` for the default.
     """
-    global _exec_cache
-    directory = str(cache_dir) if cache_dir is not None else _DEFAULT_CACHE_DIR
-    _exec_cache.close()
-    _exec_cache = Cache(directory=directory, size_limit=_EXEC_CACHE_SIZE_LIMIT)
+    global _cache_dir, _exec_cache
+    _cache_dir = str(cache_dir) if cache_dir is not None else _DEFAULT_CACHE_DIR
+    if _exec_cache is not None:
+        _exec_cache.close()
+    _exec_cache = None  # reopened lazily at _cache_dir on next use
 
 
 def clear_exec_cache() -> None:
@@ -75,7 +82,7 @@ def clear_exec_cache() -> None:
     reconciliation to bound the cache to a single reconciliation, though the size limit
     already prevents unbounded growth.
     """
-    _exec_cache.clear()
+    _get_cache().clear()
 
 
 def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
@@ -87,10 +94,11 @@ def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
             pass an explicit key for commands that reference a nondeterministic path
             (e.g. the tempfile used by ``validate_alert_rules``), so the cache still hits.
     """
+    cache = _get_cache()
     key = tuple(cache_key) if cache_key is not None else tuple(cmd)
     # diskcache ships no type stubs, so ``get``/``set`` are untyped; we only ever store
     # ``str`` under these keys, so cast the retrieved value back to ``str``.
-    cached = cast(Optional[str], _exec_cache.get(key))  # pyright: ignore[reportUnknownMemberType]
+    cached = cast(Optional[str], cache.get(key))  # pyright: ignore[reportUnknownMemberType]
     if cached is not None:
         logger.debug("cache hit for cos-tool invocation: %s", cmd)
         return cached
@@ -98,7 +106,7 @@ def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
         list(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
     output = result.stdout.decode("utf-8").strip()
-    _exec_cache.set(key, output)  # pyright: ignore[reportUnknownMemberType]
+    cache.set(key, output)  # pyright: ignore[reportUnknownMemberType]
     return output
 
 

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -30,32 +30,40 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 # aggregation deployment with room to grow.
 _EXEC_CACHE_SIZE_LIMIT = 256 * 1024 * 1024  # 256 MiB
 
+# Default on-disk location for the cache when ``configure_cache`` is not called. A fixed,
+# shared path (rather than a random temp dir) means all processes reuse the same cache, so
+# even callers that never configure a persistent directory get cross-process reuse for the
+# lifetime of this directory. Juju serialises hook execution per unit, so there is no
+# concurrent writer. Note ``/tmp`` typically does not survive a reboot / pod recreation;
+# use ``configure_cache`` with real persistent storage when that matters.
+_DEFAULT_CACHE_DIR = "/tmp/cosl-cos-tool"  # noqa: S108
+
 # Module-level, process-wide cache shared by all CosTool instances: cos-tool results
 # depend only on their inputs, not on which instance produced them, so results are
 # reusable across the many short-lived instances created during rule processing.
 #
-# Until configured with a persistent directory, it uses a temporary directory that lives
-# for the process (like the previous in-memory memoization). ``configure_cache`` points
-# it at persistent storage so results survive across process invocations (each Juju event
-# is a fresh process, which would otherwise always start cold).
-_exec_cache = Cache(size_limit=_EXEC_CACHE_SIZE_LIMIT)
+# It defaults to a fixed on-disk directory (see ``_DEFAULT_CACHE_DIR``). ``configure_cache``
+# points it at a different (e.g. charm-persistent) directory so results survive beyond what
+# ``/tmp`` offers (each Juju event is a fresh process, which would otherwise start cold).
+_exec_cache = Cache(directory=_DEFAULT_CACHE_DIR, size_limit=_EXEC_CACHE_SIZE_LIMIT)
 
 
 def configure_cache(cache_dir: Optional[Union[str, Path]]) -> None:
-    """Enable on-disk persistence of the cos-tool result cache.
+    """Point the cos-tool result cache at a specific directory.
 
-    By default the cache lives in a temporary directory and starts cold in every process.
-    Charms that reconcile on every Juju event spawn a fresh process each time, so they
-    never benefit from a previous run's work. Point this at a persistent directory (e.g. a
-    charm's persistent storage mount) to carry the cache across process invocations.
+    By default the cache lives at a fixed shared path (``/tmp/cosl-cos-tool``), which gives
+    cross-process reuse but does not survive a reboot or pod recreation. Charms reconcile on
+    every Juju event (a fresh process each time), so point this at a persistent directory
+    (e.g. a charm's persistent storage mount) to carry the cache across process invocations
+    reliably.
 
-    Passing ``None`` reverts to a process-local temporary cache.
+    Passing ``None`` reverts to the default shared location.
 
     Args:
-        cache_dir: directory in which to store the cache, or ``None`` for a temporary one.
+        cache_dir: directory in which to store the cache, or ``None`` for the default.
     """
     global _exec_cache
-    directory = str(cache_dir) if cache_dir is not None else None
+    directory = str(cache_dir) if cache_dir is not None else _DEFAULT_CACHE_DIR
     _exec_cache.close()
     _exec_cache = Cache(directory=directory, size_limit=_EXEC_CACHE_SIZE_LIMIT)
 

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -86,16 +86,6 @@ def configure_cache(cache_dir: Optional[Union[str, Path]]) -> None:
     _exec_cache = None  # reopened lazily at _cache_dir on next use
 
 
-def clear_exec_cache() -> None:
-    """Clear the memoization cache of cos-tool invocations.
-
-    Charms that reconcile their whole state on every event may call this at the start of a
-    reconciliation to bound the cache to a single reconciliation, though the size limit
-    already prevents unbounded growth.
-    """
-    _get_cache().clear()
-
-
 @functools.lru_cache(maxsize=None)
 def _cosl_version() -> str:
     """Return the installed ``cosl`` version (or ``"0"`` if it can't be determined)."""

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -3,11 +3,14 @@
 
 """COS Tool."""
 
+import functools
 import logging
+import os
 import platform
 import re
 import subprocess
 import tempfile
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
@@ -93,6 +96,38 @@ def clear_exec_cache() -> None:
     _get_cache().clear()
 
 
+@functools.lru_cache(maxsize=None)
+def _cosl_version() -> str:
+    """Return the installed ``cosl`` version (or ``"0"`` if it can't be determined)."""
+    try:
+        return version("cosl")
+    except PackageNotFoundError:
+        return "0"
+
+
+@functools.lru_cache(maxsize=None)
+def _binary_fingerprint(path: str) -> str:
+    """Return a cheap fingerprint of the cos-tool binary at ``path``.
+
+    Uses size + mtime rather than a content hash: it detects a replaced binary while
+    staying effectively free (one ``stat``, no multi-MB read), memoized per path.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return "missing"
+    return f"{st.st_size}:{st.st_mtime_ns}"
+
+
+def _fingerprint(binary_path: str) -> str:
+    """Return a fingerprint invalidating the cache when results could change.
+
+    Combines the ``cosl`` version and the binary's size+mtime, so a library upgrade or a
+    replaced cos-tool binary yields new cache keys instead of serving stale output.
+    """
+    return f"cosl={_cosl_version()};bin={_binary_fingerprint(binary_path)}"
+
+
 def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
     """Run a cos-tool command, memoizing its (deterministic) output.
 
@@ -103,7 +138,10 @@ def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
             (e.g. the tempfile used by ``validate_alert_rules``), so the cache still hits.
     """
     cache = _get_cache()
-    key = tuple(cache_key) if cache_key is not None else tuple(cmd)
+    # Prefix the key with a fingerprint (cosl version + binary size/mtime) so a library
+    # upgrade or a replaced cos-tool binary invalidates entries automatically, rather than
+    # silently returning output computed by a previous binary. cmd[0] is the binary path.
+    key = (_fingerprint(cmd[0]),) + (tuple(cache_key) if cache_key is not None else tuple(cmd))
     # diskcache ships no type stubs, so ``get``/``set`` are untyped; we only ever store
     # ``str`` under these keys, so cast the retrieved value back to ``str``.
     cached = cast(Optional[str], cache.get(key))  # pyright: ignore[reportUnknownMemberType]

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -92,6 +92,7 @@ def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
     # ``str`` under these keys, so cast the retrieved value back to ``str``.
     cached = cast(Optional[str], _exec_cache.get(key))  # pyright: ignore[reportUnknownMemberType]
     if cached is not None:
+        logger.debug("cache hit for cos-tool invocation: %s", cmd)
         return cached
     result = subprocess.run(
         list(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -23,12 +23,16 @@ _F = TypeVar("_F", bound=Callable[..., Any])
 
 # Upper bound (in bytes) for the on-disk cos-tool result cache. cos-tool is invoked once
 # per alert expression and its (deterministic) results are memoized to avoid the dominant
-# cost: the subprocess spawn (~tens of ms) on every reconcile. diskcache evicts least-
-# recently-used entries once this size is exceeded, so the cache never grows unbounded
-# while staying "hot" for the expressions actually in use. Entries are short strings, so
-# this comfortably holds the distinct expressions of a large (hundreds of apps)
-# aggregation deployment with room to grow.
+# cost: the subprocess spawn (~tens of ms) on every reconcile. Once the size limit is
+# exceeded, the least-recently-*used* entries are evicted (see ``_EXEC_CACHE_EVICTION``),
+# so the cache never grows unbounded while staying "hot" for the expressions actually in
+# use. Entries are short strings, so this comfortably holds the distinct expressions of a
+# large (hundreds of apps) aggregation deployment with room to grow.
 _EXEC_CACHE_SIZE_LIMIT = 256 * 1024 * 1024  # 256 MiB
+
+# Evict the least-recently-*used* entries (not diskcache's default least-recently-stored),
+# so entries that keep being looked up survive and only genuinely stale ones are dropped.
+_EXEC_CACHE_EVICTION = "least-recently-used"
 
 # Default on-disk location for the cache when ``configure_cache`` is not called. A fixed,
 # shared path (rather than a random temp dir) means all processes reuse the same cache, so
@@ -49,7 +53,11 @@ def _get_cache() -> Cache:
     """Return the process-wide cache, opening it at ``_cache_dir`` on first use."""
     global _exec_cache
     if _exec_cache is None:
-        _exec_cache = Cache(directory=_cache_dir, size_limit=_EXEC_CACHE_SIZE_LIMIT)
+        _exec_cache = Cache(
+            directory=_cache_dir,
+            size_limit=_EXEC_CACHE_SIZE_LIMIT,
+            eviction_policy=_EXEC_CACHE_EVICTION,
+        )
     return _exec_cache
 
 

--- a/tests/test_cos_tool.py
+++ b/tests/test_cos_tool.py
@@ -6,7 +6,7 @@ import unittest.mock
 from pathlib import PosixPath
 
 from cosl import CosTool
-from cosl.cos_tool import clear_exec_cache
+from cosl.cos_tool import _exec, clear_exec_cache, configure_cache
 
 
 class TestTool(unittest.TestCase):
@@ -101,4 +101,99 @@ class TestExecCache(unittest.TestCase):
         CosTool(default_query_type="promql").inject_label_matchers("up", topology)
         CosTool(default_query_type="promql").inject_label_matchers("up", topology)
 
+        self.assertEqual(mock_run.call_count, 1)
+
+
+class TestExecCachePersistence(unittest.TestCase):
+    """Test on-disk persistence of the cos-tool cache across processes."""
+
+    def setUp(self):
+        clear_exec_cache()
+        # Revert to a process-local temporary cache after each test.
+        self.addCleanup(configure_cache, None)
+
+    def test_persisted_cache_reused_across_processes(self):
+        """Results written under a directory are reused after reconfiguring to it.
+
+        Reconfiguring to the same directory simulates a brand-new process (a fresh
+        Juju event) pointed at the same persistent storage.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            configure_cache(tmpdir)
+            with unittest.mock.patch(
+                "cosl.cos_tool.subprocess.run",
+                return_value=unittest.mock.Mock(stdout=b"transformed"),
+            ) as mock_run:
+                out = _exec(["cos-tool", "transform", "up"], cache_key=("k", "1"))
+                self.assertEqual(out, "transformed")
+                self.assertEqual(mock_run.call_count, 1)
+
+            # Simulate a brand-new process: reopen the cache at the same directory.
+            configure_cache(tmpdir)
+            with unittest.mock.patch("cosl.cos_tool.subprocess.run") as mock_run:
+                out = _exec(["cos-tool", "transform", "up"], cache_key=("k", "1"))
+                self.assertEqual(out, "transformed")
+                # No subprocess spawned: served from the on-disk cache.
+                self.assertEqual(mock_run.call_count, 0)
+
+    def test_temporary_cache_when_unconfigured(self):
+        """Without configure_cache, memoization still works within the process."""
+        clear_exec_cache()
+        with unittest.mock.patch(
+            "cosl.cos_tool.subprocess.run",
+            return_value=unittest.mock.Mock(stdout=b"x"),
+        ) as mock_run:
+            first = _exec(["cmd"], cache_key=("k",))
+            second = _exec(["cmd"], cache_key=("k",))
+            self.assertEqual(first, "x")
+            self.assertEqual(second, "x")
+            # Memoized: only one subprocess even without a configured directory.
+            self.assertEqual(mock_run.call_count, 1)
+
+    def test_reconfigure_to_none_starts_fresh(self):
+        """Reverting to a temporary cache does not see the previous directory's data."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            configure_cache(tmpdir)
+            with unittest.mock.patch(
+                "cosl.cos_tool.subprocess.run",
+                return_value=unittest.mock.Mock(stdout=b"persisted"),
+            ):
+                _exec(["cmd"], cache_key=("k",))
+
+            configure_cache(None)  # fresh temporary cache
+            with unittest.mock.patch(
+                "cosl.cos_tool.subprocess.run",
+                return_value=unittest.mock.Mock(stdout=b"fresh"),
+            ) as mock_run:
+                out = _exec(["cmd"], cache_key=("k",))
+                self.assertEqual(out, "fresh")
+                self.assertEqual(mock_run.call_count, 1)
+
+
+class TestValidateCaching(unittest.TestCase):
+    """Validation must be memoized by rule content, not by the tempfile path."""
+
+    def setUp(self):
+        clear_exec_cache()
+        self.addCleanup(clear_exec_cache)
+
+    @unittest.mock.patch("cosl.cos_tool.CosTool._get_tool_path")
+    @unittest.mock.patch("cosl.cos_tool.subprocess.run")
+    def test_identical_rules_validated_once(self, mock_run, mock_get_path):
+        """Validating identical rules twice should spawn the subprocess only once."""
+        mock_get_path.return_value = PosixPath("/usr/bin/cos-tool-amd64")
+        mock_run.return_value = unittest.mock.Mock(stdout=b"")
+        tool = CosTool(default_query_type="promql")
+        rules = {"groups": [{"name": "g", "rules": [{"alert": "A", "expr": "up"}]}]}
+
+        first_ok, _ = tool.validate_alert_rules(rules)
+        second_ok, _ = tool.validate_alert_rules(rules)
+
+        self.assertTrue(first_ok)
+        self.assertTrue(second_ok)
+        # Previously this was 2 because the random tempfile path defeated memoization.
         self.assertEqual(mock_run.call_count, 1)

--- a/tests/test_cos_tool.py
+++ b/tests/test_cos_tool.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import os
 import subprocess
 import tempfile
 import unittest
@@ -197,9 +198,22 @@ class TestExecCachePersistence(unittest.TestCase):
         # WHEN the cache is reset to its default
         configure_cache(None)
 
-        # THEN it points at the fixed, shared location under /tmp
-        self.assertEqual(cos_tool._exec_cache.directory, cos_tool._DEFAULT_CACHE_DIR)
+        # THEN the target directory is the fixed, shared location under /tmp
+        self.assertEqual(cos_tool._cache_dir, cos_tool._DEFAULT_CACHE_DIR)
         self.assertEqual(cos_tool._DEFAULT_CACHE_DIR, "/tmp/cosl-cos-tool")
+
+    def test_import_has_no_filesystem_side_effects(self):
+        """Opening the cache is lazy: configuring a dir must not create it eagerly."""
+        import cosl.cos_tool as cos_tool
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "not-created-yet")
+            # WHEN a directory is configured but the cache is never used
+            configure_cache(target)
+
+            # THEN the directory is not created until first use
+            self.assertFalse(os.path.exists(target))
+            self.assertIsNone(cos_tool._exec_cache)
 
 
 class TestValidateCaching(unittest.TestCase):

--- a/tests/test_cos_tool.py
+++ b/tests/test_cos_tool.py
@@ -8,6 +8,7 @@ import unittest
 import unittest.mock
 from pathlib import PosixPath
 
+import cosl.cos_tool as cos_tool
 from cosl import CosTool
 from cosl.cos_tool import _exec, clear_exec_cache, configure_cache
 
@@ -193,8 +194,6 @@ class TestExecCachePersistence(unittest.TestCase):
 
     def test_default_cache_location(self):
         """Without configure_cache (or with None), the cache uses the shared default dir."""
-        import cosl.cos_tool as cos_tool
-
         # WHEN the cache is reset to its default
         configure_cache(None)
 
@@ -204,8 +203,6 @@ class TestExecCachePersistence(unittest.TestCase):
 
     def test_import_has_no_filesystem_side_effects(self):
         """Opening the cache is lazy: configuring a dir must not create it eagerly."""
-        import cosl.cos_tool as cos_tool
-
         with tempfile.TemporaryDirectory() as tmpdir:
             target = os.path.join(tmpdir, "not-created-yet")
             # WHEN a directory is configured but the cache is never used

--- a/tests/test_cos_tool.py
+++ b/tests/test_cos_tool.py
@@ -21,6 +21,20 @@ def spy_on_cos_tool():
     return unittest.mock.patch("cosl.cos_tool.subprocess.run", side_effect=subprocess.run)
 
 
+def isolate_cache(test_case):
+    """Point the cache at a fresh temp dir for the duration of ``test_case``.
+
+    Keeps tests off the shared default location (``/tmp/cosl-cos-tool``) so they neither
+    read stale entries nor pollute it, and restores the default when the test finishes.
+    """
+    tmp = tempfile.TemporaryDirectory()
+    test_case.addCleanup(tmp.cleanup)
+    test_case.addCleanup(configure_cache, None)
+    configure_cache(tmp.name)
+    clear_exec_cache()
+    return tmp.name
+
+
 class TestTool(unittest.TestCase):
     """Test that the cos-tool base implementation works."""
 
@@ -70,8 +84,7 @@ class TestExecCache(unittest.TestCase):
     """Test that cos-tool invocations are memoized to avoid redundant subprocess calls."""
 
     def setUp(self):
-        clear_exec_cache()
-        self.addCleanup(clear_exec_cache)
+        isolate_cache(self)
         # These tests run the real binary (resolved as cos-tool-<arch> in CWD).
         if CosTool(default_query_type="promql").path is None:
             self.skipTest("real cos-tool binary not available")
@@ -109,9 +122,9 @@ class TestExecCachePersistence(unittest.TestCase):
     """Test on-disk persistence of the cos-tool cache across processes."""
 
     def setUp(self):
-        clear_exec_cache()
-        # Revert to a process-local temporary cache after each test.
-        self.addCleanup(configure_cache, None)
+        # Isolate every test from the shared default cache: point at a fresh temp dir and
+        # restore the default afterwards so tests neither read nor pollute /tmp/cosl-cos-tool.
+        isolate_cache(self)
 
     def test_persisted_cache_reused_across_processes(self):
         """Results written under a directory are reused after reconfiguring to it.
@@ -139,10 +152,9 @@ class TestExecCachePersistence(unittest.TestCase):
                 self.assertEqual(out, "transformed")
                 self.assertEqual(mock_run.call_count, 0)
 
-    def test_temporary_cache_when_unconfigured(self):
-        """Without configure_cache, memoization still works within the process."""
-        # GIVEN no cache directory configured (process-local temporary cache)
-        clear_exec_cache()
+    def test_cache_memoizes_within_a_directory(self):
+        """A configured cache memoizes: identical calls run the subprocess only once."""
+        # GIVEN a cache pointed at a directory (the setUp temp dir)
         with unittest.mock.patch(
             "cosl.cos_tool.subprocess.run",
             return_value=unittest.mock.Mock(stdout=b"x"),
@@ -151,41 +163,50 @@ class TestExecCachePersistence(unittest.TestCase):
             first = _exec(["cmd"], cache_key=("k",))
             second = _exec(["cmd"], cache_key=("k",))
 
-            # THEN it is memoized in-process: same result, only one subprocess
+            # THEN it is memoized: same result, only one subprocess
             self.assertEqual(first, "x")
             self.assertEqual(second, "x")
             self.assertEqual(mock_run.call_count, 1)
 
-    def test_reconfigure_to_none_starts_fresh(self):
-        """Reverting to a temporary cache does not see the previous directory's data."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # GIVEN a value cached in a persistent directory
-            configure_cache(tmpdir)
-            with unittest.mock.patch(
-                "cosl.cos_tool.subprocess.run",
-                return_value=unittest.mock.Mock(stdout=b"persisted"),
-            ):
-                _exec(["cmd"], cache_key=("k",))
+    def test_reconfigure_switches_directory(self):
+        """Reconfiguring to a different directory does not see the previous one's data."""
+        # GIVEN a value cached in the current (setUp) directory
+        with unittest.mock.patch(
+            "cosl.cos_tool.subprocess.run",
+            return_value=unittest.mock.Mock(stdout=b"first-dir"),
+        ):
+            _exec(["cmd"], cache_key=("k",))
 
-            # WHEN the cache is reconfigured to a fresh temporary one
-            configure_cache(None)
+        # WHEN the cache is repointed at a different, empty directory
+        with tempfile.TemporaryDirectory() as other_dir:
+            configure_cache(other_dir)
             with unittest.mock.patch(
                 "cosl.cos_tool.subprocess.run",
-                return_value=unittest.mock.Mock(stdout=b"fresh"),
+                return_value=unittest.mock.Mock(stdout=b"second-dir"),
             ) as mock_run:
                 out = _exec(["cmd"], cache_key=("k",))
 
-                # THEN the previous directory's data is not visible: the binary runs again
-                self.assertEqual(out, "fresh")
+                # THEN the first directory's data is not visible: the binary runs again
+                self.assertEqual(out, "second-dir")
                 self.assertEqual(mock_run.call_count, 1)
+
+    def test_default_cache_location(self):
+        """Without configure_cache (or with None), the cache uses the shared default dir."""
+        import cosl.cos_tool as cos_tool
+
+        # WHEN the cache is reset to its default
+        configure_cache(None)
+
+        # THEN it points at the fixed, shared location under /tmp
+        self.assertEqual(cos_tool._exec_cache.directory, cos_tool._DEFAULT_CACHE_DIR)
+        self.assertEqual(cos_tool._DEFAULT_CACHE_DIR, "/tmp/cosl-cos-tool")
 
 
 class TestValidateCaching(unittest.TestCase):
     """Validation must be memoized by rule content, not by the tempfile path."""
 
     def setUp(self):
-        clear_exec_cache()
-        self.addCleanup(clear_exec_cache)
+        isolate_cache(self)
         # Runs the real binary (resolved as cos-tool-<arch> in CWD).
         if CosTool(default_query_type="promql").path is None:
             self.skipTest("real cos-tool binary not available")
@@ -217,9 +238,7 @@ class TestCacheFidelity(unittest.TestCase):
     """
 
     def setUp(self):
-        clear_exec_cache()
-        self.addCleanup(clear_exec_cache)
-        self.addCleanup(configure_cache, None)
+        isolate_cache(self)
         # These tests require the real cos-tool binary (resolved as cos-tool-<arch> in CWD).
         if CosTool(default_query_type="promql").path is None:
             self.skipTest("real cos-tool binary not available")

--- a/tests/test_cos_tool.py
+++ b/tests/test_cos_tool.py
@@ -212,6 +212,40 @@ class TestExecCachePersistence(unittest.TestCase):
             self.assertFalse(os.path.exists(target))
             self.assertIsNone(cos_tool._exec_cache)
 
+    def test_cache_uses_lru_eviction(self):
+        """The cache evicts least-recently-*used* entries, not least-recently-stored."""
+        # WHEN the cache is opened
+        cache = cos_tool._get_cache()
+
+        # THEN it is configured with the least-recently-used eviction policy
+        self.assertEqual(cache.eviction_policy, "least-recently-used")
+
+    def test_changed_binary_fingerprint_invalidates_cache(self):
+        """A changed binary fingerprint must miss the cache instead of serving stale output."""
+        cos_tool._binary_fingerprint.cache_clear()
+        self.addCleanup(cos_tool._binary_fingerprint.cache_clear)
+
+        # GIVEN a value cached under one binary fingerprint
+        with unittest.mock.patch.object(cos_tool, "_fingerprint", return_value="fp-v1"):
+            with unittest.mock.patch(
+                "cosl.cos_tool.subprocess.run",
+                return_value=unittest.mock.Mock(stdout=b"v1-output"),
+            ):
+                first = _exec(["cos-tool", "transform", "up"], cache_key=("k",))
+                self.assertEqual(first, "v1-output")
+
+        # WHEN the binary fingerprint changes (e.g. the binary was replaced)
+        with unittest.mock.patch.object(cos_tool, "_fingerprint", return_value="fp-v2"):
+            with unittest.mock.patch(
+                "cosl.cos_tool.subprocess.run",
+                return_value=unittest.mock.Mock(stdout=b"v2-output"),
+            ) as mock_run:
+                out = _exec(["cos-tool", "transform", "up"], cache_key=("k",))
+
+                # THEN it is a cache miss: the binary runs again, no stale value served
+                self.assertEqual(out, "v2-output")
+                self.assertEqual(mock_run.call_count, 1)
+
 
 class TestValidateCaching(unittest.TestCase):
     """Validation must be memoized by rule content, not by the tempfile path."""

--- a/tests/test_cos_tool.py
+++ b/tests/test_cos_tool.py
@@ -10,7 +10,7 @@ from pathlib import PosixPath
 
 import cosl.cos_tool as cos_tool
 from cosl import CosTool
-from cosl.cos_tool import _exec, clear_exec_cache, configure_cache
+from cosl.cos_tool import _exec, configure_cache
 
 
 def spy_on_cos_tool():
@@ -33,7 +33,6 @@ def isolate_cache(test_case):
     test_case.addCleanup(tmp.cleanup)
     test_case.addCleanup(configure_cache, None)
     configure_cache(tmp.name)
-    clear_exec_cache()
     return tmp.name
 
 

--- a/tests/test_cos_tool.py
+++ b/tests/test_cos_tool.py
@@ -1,12 +1,24 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import subprocess
+import tempfile
 import unittest
 import unittest.mock
 from pathlib import PosixPath
 
 from cosl import CosTool
 from cosl.cos_tool import _exec, clear_exec_cache, configure_cache
+
+
+def spy_on_cos_tool():
+    """Patch ``subprocess.run`` to still run the real binary while counting calls.
+
+    Returns a patcher whose mock has ``side_effect=real_run``, so the real cos-tool
+    binary is executed (real output) while ``call_count`` lets a test assert whether the
+    cache avoided a subprocess. Use as a context manager: ``with spy_on_cos_tool() as spy``.
+    """
+    return unittest.mock.patch("cosl.cos_tool.subprocess.run", side_effect=subprocess.run)
 
 
 class TestTool(unittest.TestCase):
@@ -60,48 +72,37 @@ class TestExecCache(unittest.TestCase):
     def setUp(self):
         clear_exec_cache()
         self.addCleanup(clear_exec_cache)
+        # These tests run the real binary (resolved as cos-tool-<arch> in CWD).
+        if CosTool(default_query_type="promql").path is None:
+            self.skipTest("real cos-tool binary not available")
 
-    @unittest.mock.patch("cosl.cos_tool.CosTool._get_tool_path")
-    @unittest.mock.patch("cosl.cos_tool.subprocess.run")
-    def test_identical_expressions_run_subprocess_once(self, mock_run, mock_get_path):
+    def test_identical_expressions_run_subprocess_once(self):
         """Identical expressions should spawn the subprocess only once."""
-        mock_get_path.return_value = PosixPath("/usr/bin/cos-tool-amd64")
-        mock_run.return_value = unittest.mock.Mock(stdout=b"up{juju_model='my_model'}")
+        # GIVEN a CosTool and an expression + topology
         tool = CosTool(default_query_type="promql")
         topology = {"juju_model": "my_model", "juju_application": "app"}
 
-        first = tool.inject_label_matchers("up", topology)
-        second = tool.inject_label_matchers("up", topology)
+        # WHEN the same expression is transformed twice
+        with spy_on_cos_tool() as spy:
+            first = tool.inject_label_matchers("up", topology)
+            second = tool.inject_label_matchers("up", topology)
 
-        self.assertEqual(first, "up{juju_model='my_model'}")
-        self.assertEqual(second, "up{juju_model='my_model'}")
-        self.assertEqual(mock_run.call_count, 1)
+        # THEN both calls return the same (real) result and cos-tool ran only once
+        self.assertEqual(first, second)
+        self.assertEqual(spy.call_count, 1)
 
-    @unittest.mock.patch("cosl.cos_tool.CosTool._get_tool_path")
-    @unittest.mock.patch("cosl.cos_tool.subprocess.run")
-    def test_different_expressions_run_subprocess_each(self, mock_run, mock_get_path):
+    def test_different_expressions_run_subprocess_each(self):
         """Different expressions should each spawn a subprocess."""
-        mock_get_path.return_value = PosixPath("/usr/bin/cos-tool-amd64")
-        mock_run.return_value = unittest.mock.Mock(stdout=b"result")
+        # GIVEN a CosTool
         tool = CosTool(default_query_type="promql")
 
-        tool.inject_label_matchers("up", {"juju_model": "m"})
-        tool.inject_label_matchers("down", {"juju_model": "m"})
+        # WHEN two different expressions are transformed
+        with spy_on_cos_tool() as spy:
+            tool.inject_label_matchers("up", {"juju_model": "m"})
+            tool.inject_label_matchers("down", {"juju_model": "m"})
 
-        self.assertEqual(mock_run.call_count, 2)
-
-    @unittest.mock.patch("cosl.cos_tool.CosTool._get_tool_path")
-    @unittest.mock.patch("cosl.cos_tool.subprocess.run")
-    def test_cache_shared_across_instances(self, mock_run, mock_get_path):
-        """The cache is shared across CosTool instances."""
-        mock_get_path.return_value = PosixPath("/usr/bin/cos-tool-amd64")
-        mock_run.return_value = unittest.mock.Mock(stdout=b"result")
-        topology = {"juju_model": "my_model"}
-
-        CosTool(default_query_type="promql").inject_label_matchers("up", topology)
-        CosTool(default_query_type="promql").inject_label_matchers("up", topology)
-
-        self.assertEqual(mock_run.call_count, 1)
+        # THEN cos-tool runs once per distinct expression
+        self.assertEqual(spy.call_count, 2)
 
 
 class TestExecCachePersistence(unittest.TestCase):
@@ -118,9 +119,8 @@ class TestExecCachePersistence(unittest.TestCase):
         Reconfiguring to the same directory simulates a brand-new process (a fresh
         Juju event) pointed at the same persistent storage.
         """
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
+            # GIVEN a persistent cache populated by running cos-tool once
             configure_cache(tmpdir)
             with unittest.mock.patch(
                 "cosl.cos_tool.subprocess.run",
@@ -130,33 +130,36 @@ class TestExecCachePersistence(unittest.TestCase):
                 self.assertEqual(out, "transformed")
                 self.assertEqual(mock_run.call_count, 1)
 
-            # Simulate a brand-new process: reopen the cache at the same directory.
+            # WHEN a brand-new process reopens the cache at the same directory
             configure_cache(tmpdir)
             with unittest.mock.patch("cosl.cos_tool.subprocess.run") as mock_run:
                 out = _exec(["cos-tool", "transform", "up"], cache_key=("k", "1"))
+
+                # THEN the value is served from disk without spawning the subprocess
                 self.assertEqual(out, "transformed")
-                # No subprocess spawned: served from the on-disk cache.
                 self.assertEqual(mock_run.call_count, 0)
 
     def test_temporary_cache_when_unconfigured(self):
         """Without configure_cache, memoization still works within the process."""
+        # GIVEN no cache directory configured (process-local temporary cache)
         clear_exec_cache()
         with unittest.mock.patch(
             "cosl.cos_tool.subprocess.run",
             return_value=unittest.mock.Mock(stdout=b"x"),
         ) as mock_run:
+            # WHEN the same command is executed twice
             first = _exec(["cmd"], cache_key=("k",))
             second = _exec(["cmd"], cache_key=("k",))
+
+            # THEN it is memoized in-process: same result, only one subprocess
             self.assertEqual(first, "x")
             self.assertEqual(second, "x")
-            # Memoized: only one subprocess even without a configured directory.
             self.assertEqual(mock_run.call_count, 1)
 
     def test_reconfigure_to_none_starts_fresh(self):
         """Reverting to a temporary cache does not see the previous directory's data."""
-        import tempfile
-
         with tempfile.TemporaryDirectory() as tmpdir:
+            # GIVEN a value cached in a persistent directory
             configure_cache(tmpdir)
             with unittest.mock.patch(
                 "cosl.cos_tool.subprocess.run",
@@ -164,12 +167,15 @@ class TestExecCachePersistence(unittest.TestCase):
             ):
                 _exec(["cmd"], cache_key=("k",))
 
-            configure_cache(None)  # fresh temporary cache
+            # WHEN the cache is reconfigured to a fresh temporary one
+            configure_cache(None)
             with unittest.mock.patch(
                 "cosl.cos_tool.subprocess.run",
                 return_value=unittest.mock.Mock(stdout=b"fresh"),
             ) as mock_run:
                 out = _exec(["cmd"], cache_key=("k",))
+
+                # THEN the previous directory's data is not visible: the binary runs again
                 self.assertEqual(out, "fresh")
                 self.assertEqual(mock_run.call_count, 1)
 
@@ -180,20 +186,107 @@ class TestValidateCaching(unittest.TestCase):
     def setUp(self):
         clear_exec_cache()
         self.addCleanup(clear_exec_cache)
+        # Runs the real binary (resolved as cos-tool-<arch> in CWD).
+        if CosTool(default_query_type="promql").path is None:
+            self.skipTest("real cos-tool binary not available")
 
-    @unittest.mock.patch("cosl.cos_tool.CosTool._get_tool_path")
-    @unittest.mock.patch("cosl.cos_tool.subprocess.run")
-    def test_identical_rules_validated_once(self, mock_run, mock_get_path):
+    def test_identical_rules_validated_once(self):
         """Validating identical rules twice should spawn the subprocess only once."""
-        mock_get_path.return_value = PosixPath("/usr/bin/cos-tool-amd64")
-        mock_run.return_value = unittest.mock.Mock(stdout=b"")
+        # GIVEN a CosTool and a set of rules
         tool = CosTool(default_query_type="promql")
         rules = {"groups": [{"name": "g", "rules": [{"alert": "A", "expr": "up"}]}]}
 
-        first_ok, _ = tool.validate_alert_rules(rules)
-        second_ok, _ = tool.validate_alert_rules(rules)
+        # WHEN the same rules are validated twice
+        with spy_on_cos_tool() as spy:
+            first_ok, _ = tool.validate_alert_rules(rules)
+            second_ok, _ = tool.validate_alert_rules(rules)
 
+        # THEN both validate successfully and cos-tool ran only once.
+        # (Previously this was 2 because the random tempfile path defeated memoization.)
         self.assertTrue(first_ok)
         self.assertTrue(second_ok)
-        # Previously this was 2 because the random tempfile path defeated memoization.
-        self.assertEqual(mock_run.call_count, 1)
+        self.assertEqual(spy.call_count, 1)
+
+
+class TestCacheFidelity(unittest.TestCase):
+    """The cached value must be byte-identical to what the real cos-tool binary returns.
+
+    These tests do NOT mock cos-tool: they run the real binary once (populating the cache),
+    then read back from the cache, and assert the two results are identical. This guards
+    the memoization layer we introduced between the caller and the binary.
+    """
+
+    def setUp(self):
+        clear_exec_cache()
+        self.addCleanup(clear_exec_cache)
+        self.addCleanup(configure_cache, None)
+        # These tests require the real cos-tool binary (resolved as cos-tool-<arch> in CWD).
+        if CosTool(default_query_type="promql").path is None:
+            self.skipTest("real cos-tool binary not available")
+
+    def _assert_cached_equals_binary(self, call):
+        """Run ``call`` twice (miss then hit) and assert identical output from the cache.
+
+        Encapsulates the WHEN/THEN of the fidelity tests: it also asserts the second call
+        is served from the cache (no subprocess), so a deterministic binary can't make the
+        test pass without the cache working.
+
+        Args:
+            call: a zero-arg callable that invokes cos-tool via the library.
+        """
+        with spy_on_cos_tool() as spy:
+            # WHEN the call runs the first time (cache miss -> runs the real binary)
+            from_binary = call()
+            runs_after_first = spy.call_count
+            self.assertGreaterEqual(runs_after_first, 1, "first call should run the binary")
+
+            # WHEN the same call runs again (cache hit -> should not run the binary)
+            from_cache = call()
+            # THEN the second call is served from the cache (no extra subprocess)
+            self.assertEqual(
+                spy.call_count,
+                runs_after_first,
+                "second call must be served from the cache (no extra subprocess)",
+            )
+
+        # THEN the cached value is byte-identical to the binary's output
+        self.assertEqual(from_binary, from_cache, "cached value differs from binary output")
+        return from_binary
+
+    def test_inject_label_matchers_cached_equals_binary(self):
+        """Transformed expression from cache is identical to the binary's output."""
+        # GIVEN a CosTool and an expression + topology
+        tool = CosTool(default_query_type="promql")
+        topology = {"juju_model": "m", "juju_model_uuid": "uuid", "juju_application": "app"}
+
+        # WHEN it is transformed (miss) and then read back (hit)
+        # THEN both are identical (asserted in the helper)
+        result = self._assert_cached_equals_binary(
+            lambda: tool.inject_label_matchers("up == 0", topology)
+        )
+        # THEN the binary actually injected the labels (not a passthrough)
+        self.assertIn("juju_application", result)
+
+    def test_cached_value_survives_fresh_cache_open(self):
+        """A value written to disk is read back identically after reopening the cache.
+
+        This mirrors a fresh Juju event: a new process opens the persisted cache and must
+        get exactly what the binary produced in a previous process.
+        """
+        tool = CosTool(default_query_type="promql")
+        topology = {"juju_model": "m", "juju_application": "app"}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # GIVEN an expression transformed by the real binary into a persistent cache
+            configure_cache(tmpdir)
+            with spy_on_cos_tool():
+                from_binary = tool.inject_label_matchers("up == 0", topology)
+
+            # WHEN a fresh process reopens the cache and requests the same expression
+            configure_cache(tmpdir)
+            with unittest.mock.patch("cosl.cos_tool.subprocess.run") as spy:
+                from_reopened_cache = tool.inject_label_matchers("up == 0", topology)
+                # THEN the value comes from the cache (no subprocess)
+                self.assertEqual(spy.call_count, 0, "value should come from the reopened cache")
+
+            # THEN the reopened-cache value is identical to the binary's original output
+            self.assertEqual(from_binary, from_reopened_cache)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -229,9 +229,10 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.10.0"
+version = "1.10.2"
 source = { editable = "." }
 dependencies = [
+    { name = "diskcache" },
     { name = "ops", version = "2.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ops", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -272,6 +273,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
     { name = "codespell", marker = "extra == 'dev'" },
     { name = "deepdiff", marker = "extra == 'dev'" },
+    { name = "diskcache" },
     { name = "fs", marker = "extra == 'dev'" },
     { name = "ops" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
@@ -637,6 +639,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

`cos-tool` is invoked once per alert-rule expression (to inject Juju topology label matchers and to validate rules), and each invocation is a subprocess spawn costing on the order of tens of milliseconds. It is the dominant cost of rule processing in aggregator charms.

Two problems made this worse than necessary:

1. **The memoization cache did not survive across processes.** The previous cache was an in-process `functools.lru_cache`. Some charms may reconcile their whole state on every Juju event (for instance [`opentelemetry-collector-k8s`](https://github.com/canonical/opentelemetry-collector-k8s-operator/blob/b1a9814d6a18f7259ac32da2fbc6a9fe81bce235/src/charm.py#L244)), and each event is a **fresh process**, so the cache always started cold: every event re-ran `cos-tool` for every expression, even when nothing changed (e.g. `update-status`). At hundreds of related applications this pushes rule processing past Juju's hook timeout.

2. **Rule validation was never memoized.** `validate_alert_rules` wrote the rules to a randomly-named tempfile and passed that path to `cos-tool`. Because the path was part of the cache key and changed on every call, validation never hit the cache — not even within a single process.



## Solution
<!-- A summary of the solution addressing the above issue -->

- **Persist the cache on disk, keyed by the (deterministic) inputs of each `cos-tool` invocation.** The in-process `lru_cache` is replaced by [`diskcache`], a small, pure-Python, SQLite-backed cache. Results computed in one process are reused by subsequent processes.
- **Add `configure_cache(cache_dir)`**, a module-level function that points the cache at a specific directory (e.g. a charm's persistent storage). By default the cache uses a fixed shared location (`/tmp/cosl-cos-tool`), so even callers that never configure it get cross-process reuse; `configure_cache` is for pointing at storage that survives a reboot / pod recreation. Passing `None` reverts to the default location.
- **Fix validation memoization.** `validate_alert_rules` now keys the cache on the rule *content* rather than on the nondeterministic tempfile path, so identical rules are validated by `cos-tool` only once.
- **Bound the cache by size** (`size_limit`, 256 MiB) with LRU eviction, so it never grows unbounded while staying hot for the expressions actually in use.


### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
- [x] This change warrants a release, so I have updated the `project.version` field in the `pyproject.toml` file.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

- **Every Juju event is a fresh Python process.** Any in-memory cache is therefore lost between events, which is why persistence across processes is the key win here — not just faster lookups within one process.
- **`cos-tool` output is deterministic.** For a given `(expression, topology, query_type)` the transformed expression (and the validation result) is always the same, so it is safe to memoize. The cache key is the exact argv passed to the binary (for `transform`), or a content-derived key (for `validate`).
- **`diskcache` uses SQLite and is process-safe**, though we do not rely on concurrent writers here: Juju serialises hook execution per unit.
- **Caching lives entirely inside `cosl`.** Consumers get persistence at a shared default location out of the box; they call `configure_cache(...)` only to point at storage that survives reboots / pod recreations.
- **The default path is a fixed `/tmp/cosl-cos-tool` (not a random temp dir).** A fixed, shared path lets all processes reuse the same cache without accumulating stray temp directories. It is safe without locking because Juju serialises hook execution per unit, so there is no concurrent writer. The hardcoded `/tmp` carries a `# noqa: S108` (acceptable in the single-user charm container); callers needing multi-user isolation should pass an explicit directory via `configure_cache`.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

```
tox -e unit
```

The unit test target downloads the real `cos-tool` binary if it is missing. New tests cover:

- Memoization: identical expressions run `cos-tool` once; distinct expressions run it per expression (exercised against the real binary).
- Persistence: a value written under a directory is reused after the cache is reopened (simulating a fresh process/event); the cache memoizes within a directory; reconfiguring to a different directory does not see the previous one's data; and the default location is the shared `/tmp/cosl-cos-tool`.
- Validation is memoized by content (previously it never hit the cache).
- **Fidelity:** the value served from the cache is byte-identical to what the real `cos-tool` binary returns — including after reopening a persisted cache in a fresh process. This guards the memoization layer introduced between the caller and the binary.

## Benchmarks

The attached [`cos_tool_cache_benchmark.py`](https://github.com/user-attachments/files/30074835/cos_tool_cache_benchmark.py) measures the impact of the cache against the real cos-tool binary. Run it from the repo root (with the binary present) as:

```shell
PYTHONPATH=src python3 benchmarks/cos_tool_cache_benchmark.py --counts 3000
```

`--counts N` is the number of distinct expressions to process (e.g. 3000 ≈ 300 related applications contributing ~10 alert expressions each). 
It reports four scenarios:

- `baseline` (one cos-tool subprocess per expression, no cache),
- `cold` (cache empty, every expression is a miss)
- `hot` (cache populated, all hits within the process)
- `cross-process hot` (a fresh process opens the populated on-disk cache — the realistic per-Juju-event case). 

A run with 3000 expressions:

```shell
$ PYTHONPATH=src python3 benchmarks/cos_tool_cache_benchmark.py --counts 3000
cos-tool cache benchmark
python: 3.12.3

==============================================================================
Expressions: 3000
==============================================================================

scenario                                       total (s)       ms/op   vs baseline
----------------------------------------------------------------------------------
baseline (subprocess, no cache)                 292.8440     97.6147    1.0x (ref)
cold (diskcache, all miss)                      292.8193     97.6064          1.0x
hot (diskcache, all hit)                          0.0747      0.0249       3919.4x
cross-process hot (fresh process, all hit)        0.0734      0.0245       3992.3x

```

The results confirm the design: a `cos-tool` invocation costs `~98` ms, so processing `3000` expressions uncached takes `~293` sec. The cache does not add measurable overhead on the cold path (cold ≈ baseline, since a miss still pays the subprocess plus a cheap SQLite write). Once populated, lookups are served from SQLite in ~0.025 ms — a `~3900×` speedup, dropping the total from `~293` sec to `~0.07` sec. Crucially, `cross-process hot` is as fast as `hot`, proving that opening the on-disk cache in a fresh process (what happens on every Juju event) is negligible: a charm that re-reconciles on `update-status` or any no-op event reprocesses all `3000` expressions in tens of milliseconds instead of minutes.


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

- Adds a new runtime dependency: **`diskcache`** (pure-Python, no native build, supports Python 3.8+).
- **No API break.** The cache now persists on disk by default at a shared location (`/tmp/cosl-cos-tool`) instead of living only in memory; behaviour within a process is otherwise the same (identical inputs are memoized). 
- Consumers that need caching to survive reboots / pod recreations should call `cosl.cos_tool.configure_cache(<persistent-dir>)` once at startup, pointing at storage that survives process restarts. For example, in a charm's `__init__`, pointing at a persistent storage mount declared in `charmcraft.yaml`:

  ```python
  from cosl.cos_tool import configure_cache

  class MyCharm(ops.CharmBase):
      def __init__(self, *args):
          super().__init__(*args)
          # `cache` is a filesystem storage mounted into the charm container.
          if storages := self.model.storages["cache"]:
              configure_cache(storages[0].location)
          ...
  ```

[`diskcache`]: https://grantjenks.com/docs/diskcache/