### PR TITLE
fix: remove unnecessary (time-consuming) debug logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cosl"
-version = "1.10.2"
+version = "1.10.3"
 authors = [
     { name = "sed-i", email = "82407168+sed-i@users.noreply.github.com" },
 ]

--- a/src/cosl/cos_tool.py
+++ b/src/cosl/cos_tool.py
@@ -136,7 +136,6 @@ def _exec(cmd: List[str], cache_key: Optional[Tuple[str, ...]] = None) -> str:
     # ``str`` under these keys, so cast the retrieved value back to ``str``.
     cached = cast(Optional[str], cache.get(key))  # pyright: ignore[reportUnknownMemberType]
     if cached is not None:
-        logger.debug("cache hit for cos-tool invocation: %s", cmd)
         return cached
     result = subprocess.run(
         list(cmd), check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This log entry is generated when a cache has been hit, and much of the time saved by not running `subprocess.run` is lost because `logger.debug` is ultimately executed, which in turn results in the `juju-log` binary being run within the container.


## Solution
<!-- A summary of the solution addressing the above issue -->

### Checklist
- [x] I have added or updated relevant documentation.
- [x] PR title makes an appropriate release note and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
- [x] Merge target is the correct branch, and relevant tandem backport PRs opened. 
- [x] This change warrants a release, so I have updated the `project.version` field in the `pyproject.toml` file.


